### PR TITLE
feat: Garmin Connect dark UI — colors, Roboto font, activity icon

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,14 +18,14 @@ body {
   width: 6px;
 }
 .chat-scroll::-webkit-scrollbar-track {
-  background: transparent;
+  background: #0f1923;
 }
 .chat-scroll::-webkit-scrollbar-thumb {
-  background: #d1d5db;
+  background: #2a3f55;
   border-radius: 3px;
 }
 .chat-scroll::-webkit-scrollbar-thumb:hover {
-  background: #9ca3af;
+  background: #3a5570;
 }
 
 /* Blinking cursor on streaming text */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
+import { Roboto } from 'next/font/google';
 import './globals.css';
 
-const inter = Inter({ subsets: ['latin'] });
+const roboto = Roboto({ subsets: ['latin'], weight: ['300', '400', '500', '700'] });
 
 export const metadata: Metadata = {
   title: 'Ask My Garmin',
@@ -12,7 +12,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className={`${inter.className} bg-gray-50 text-gray-900 antialiased`}>{children}</body>
+      <body className={`${roboto.className} bg-garmin-bg text-garmin-text antialiased`}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,13 +68,13 @@ export default function Home() {
 
   return (
     <main className="flex h-dvh flex-col">
-      <header className="flex-shrink-0 border-b border-gray-200 bg-white px-4 py-3 sm:px-6 sm:py-4">
+      <header className="flex-shrink-0 border-b border-garmin-border bg-garmin-surface px-4 py-3 sm:px-6 sm:py-4">
         <div className="mx-auto flex max-w-4xl items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-garmin-blue text-white">
               <GarminIcon />
             </div>
-            <h1 className="text-lg font-semibold text-gray-900">Ask My Garmin</h1>
+            <h1 className="text-lg font-semibold text-garmin-text">Ask My Garmin</h1>
           </div>
 
           <GarminStatus

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -110,7 +110,7 @@ export default function ChatInterface() {
       </div>
 
       {/* Input area */}
-      <div className="border-t border-gray-200 bg-white px-3 py-3 sm:px-6">
+      <div className="border-t border-garmin-border bg-garmin-surface px-3 py-3 sm:px-6">
         <form onSubmit={handleSubmit} className="mx-auto flex max-w-3xl items-end gap-3">
           <textarea
             ref={inputRef}
@@ -120,7 +120,7 @@ export default function ChatInterface() {
             placeholder="Ask about your activities, sleep, heart rate…"
             rows={1}
             disabled={isStreaming}
-            className="max-h-32 flex-1 resize-none overflow-y-auto rounded-xl border border-gray-300 px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue disabled:cursor-not-allowed disabled:opacity-50"
+            className="max-h-32 flex-1 resize-none overflow-y-auto rounded-xl border border-garmin-border bg-garmin-bg px-4 py-3 text-sm text-garmin-text placeholder:text-garmin-text-muted focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue disabled:cursor-not-allowed disabled:opacity-50"
             style={{ minHeight: '44px' }}
             onInput={(e) => {
               const el = e.currentTarget;
@@ -159,7 +159,7 @@ export default function ChatInterface() {
             )}
           </button>
         </form>
-        <p className="mt-2 text-center text-xs text-gray-400">
+        <p className="mt-2 text-center text-xs text-garmin-text-muted">
           Press Enter to send · Shift+Enter for new line
         </p>
       </div>

--- a/src/components/GarminStatus.tsx
+++ b/src/components/GarminStatus.tsx
@@ -10,8 +10,8 @@ interface Props {
 export default function GarminStatus({ connected, email, onLoginClick, onLogout }: Props) {
   if (connected === null) {
     return (
-      <div className="flex items-center gap-2 text-sm text-gray-500">
-        <span className="h-2 w-2 animate-pulse rounded-full bg-gray-300" />
+      <div className="flex items-center gap-2 text-sm text-garmin-text-muted">
+        <span className="h-2 w-2 animate-pulse rounded-full bg-garmin-border" />
         Connecting…
       </div>
     );
@@ -21,20 +21,20 @@ export default function GarminStatus({ connected, email, onLoginClick, onLogout 
     return (
       <div className="flex items-center gap-3">
         <div
-          className="flex items-center gap-2 text-sm text-gray-600"
+          className="flex items-center gap-2 text-sm text-garmin-text"
           title={email ? `Connected as ${email}` : 'Connected'}
         >
-          <span className="h-2 w-2 rounded-full bg-green-500" />
+          <span className="h-2 w-2 rounded-full bg-garmin-green" />
           <span>Connected</span>
           {email && (
-            <span className="max-w-[120px] truncate text-xs text-gray-400 sm:max-w-none">
+            <span className="max-w-[120px] truncate text-xs text-garmin-text-muted sm:max-w-none">
               ({email})
             </span>
           )}
         </div>
         <button
           onClick={onLogout}
-          className="rounded-md px-3 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+          className="rounded-md px-3 py-1 text-xs text-garmin-text-muted transition-colors hover:bg-garmin-surface-2 hover:text-garmin-text"
         >
           Sign out
         </button>

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -98,16 +98,16 @@ export default function LoginModal({ onSuccess }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-      <div className="w-full max-w-sm rounded-2xl bg-white p-8 shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-2xl bg-garmin-surface p-8 shadow-xl">
         {/* Logo + title */}
         <div className="mb-6 flex flex-col items-center gap-3">
           <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-garmin-blue text-white">
             <GarminIcon size={22} />
           </div>
           <div className="text-center">
-            <h1 className="text-xl font-semibold text-gray-900">Connect your Garmin account</h1>
-            <p className="mt-1 text-sm text-gray-500">
+            <h1 className="text-xl font-semibold text-garmin-text">Connect your Garmin account</h1>
+            <p className="mt-1 text-sm text-garmin-text-muted">
               {step === 'credentials'
                 ? 'This app accesses your Garmin Connect data on your behalf.'
                 : 'Enter the code from your authenticator app or SMS'}
@@ -117,13 +117,18 @@ export default function LoginModal({ onSuccess }: Props) {
 
         {/* Error */}
         {error && (
-          <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+          <div className="mb-4 rounded-lg bg-red-900/30 px-4 py-3 text-sm text-red-400">
+            {error}
+          </div>
         )}
 
         {step === 'credentials' ? (
           <form onSubmit={handleCredentials} className="flex flex-col gap-4">
             <div>
-              <label htmlFor="login-email" className="mb-1 block text-sm font-medium text-gray-700">
+              <label
+                htmlFor="login-email"
+                className="mb-1 block text-sm font-medium text-garmin-text"
+              >
                 Email
               </label>
               <input
@@ -133,13 +138,13 @@ export default function LoginModal({ onSuccess }: Props) {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 autoComplete="email"
-                className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue"
+                className="w-full rounded-lg border border-garmin-border bg-garmin-bg px-4 py-2.5 text-sm text-garmin-text placeholder:text-garmin-text-muted focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue"
               />
             </div>
             <div>
               <label
                 htmlFor="login-password"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-garmin-text"
               >
                 Password
               </label>
@@ -150,7 +155,7 @@ export default function LoginModal({ onSuccess }: Props) {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 autoComplete="current-password"
-                className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue"
+                className="w-full rounded-lg border border-garmin-border bg-garmin-bg px-4 py-2.5 text-sm text-garmin-text placeholder:text-garmin-text-muted focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue"
               />
             </div>
             <button
@@ -161,7 +166,7 @@ export default function LoginModal({ onSuccess }: Props) {
               {loading ? 'Signing in…' : 'Sign in'}
             </button>
             {/* Security notice */}
-            <p className="flex items-center justify-center gap-1.5 text-center text-xs text-gray-400">
+            <p className="flex items-center justify-center gap-1.5 text-center text-xs text-garmin-text-muted">
               <svg
                 className="h-3.5 w-3.5 flex-shrink-0"
                 fill="none"
@@ -181,7 +186,10 @@ export default function LoginModal({ onSuccess }: Props) {
         ) : (
           <form onSubmit={handleMfa} className="flex flex-col gap-4">
             <div>
-              <label htmlFor="mfa-code" className="mb-1 block text-sm font-medium text-gray-700">
+              <label
+                htmlFor="mfa-code"
+                className="mb-1 block text-sm font-medium text-garmin-text"
+              >
                 Verification code
               </label>
               <input
@@ -195,7 +203,7 @@ export default function LoginModal({ onSuccess }: Props) {
                 onChange={(e) => setMfaCode(e.target.value)}
                 autoFocus
                 placeholder="000000"
-                className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-center font-mono text-lg tracking-widest focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue"
+                className="w-full rounded-lg border border-garmin-border bg-garmin-bg px-4 py-2.5 text-center font-mono text-lg tracking-widest text-garmin-text placeholder:text-garmin-text-muted focus:border-transparent focus:outline-none focus:ring-2 focus:ring-garmin-blue"
               />
             </div>
             <button
@@ -212,7 +220,7 @@ export default function LoginModal({ onSuccess }: Props) {
                 setError('');
                 setMfaCode('');
               }}
-              className="text-sm text-gray-500 hover:text-gray-700"
+              className="text-sm text-garmin-text-muted hover:text-garmin-text"
             >
               Back
             </button>

--- a/src/components/MessageBubble.test.tsx
+++ b/src/components/MessageBubble.test.tsx
@@ -45,10 +45,10 @@ describe('MessageBubble', () => {
     expect(bubble).toHaveTextContent('Test');
   });
 
-  it('assistant bubble has white background class', () => {
+  it('assistant bubble has dark surface background class', () => {
     const { container } = render(
       <MessageBubble message={{ role: 'assistant', content: 'Test' }} />
     );
-    expect(container.querySelector('.bg-white')).toBeInTheDocument();
+    expect(container.querySelector('.bg-garmin-surface')).toBeInTheDocument();
   });
 });

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -36,7 +36,7 @@ export default function MessageBubble({ message, isStreaming = false }: Props) {
         className={`max-w-[85%] whitespace-pre-wrap rounded-2xl px-4 py-3 text-sm leading-relaxed sm:max-w-[75%] ${
           isUser
             ? 'rounded-br-sm bg-garmin-blue text-white'
-            : 'rounded-bl-sm border border-gray-200 bg-white text-gray-800 shadow-sm'
+            : 'rounded-bl-sm border border-garmin-border bg-garmin-surface text-garmin-text shadow-sm'
         } ${isStreaming ? 'cursor-blink' : ''} `}
       >
         {message.content || (isStreaming ? '' : '…')}

--- a/src/components/SuggestedQuestions.tsx
+++ b/src/components/SuggestedQuestions.tsx
@@ -17,13 +17,13 @@ interface Props {
   onSelect: (question: string) => void;
 }
 
-function GarminIcon() {
+function ActivityIcon() {
   return (
     <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M5 12h14M13 6l6 6-6 6"
+      <polyline
+        points="2 12 6 12 8 5 10 19 13 9 15 15 17 12 22 12"
         stroke="currentColor"
-        strokeWidth="2.5"
+        strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -36,10 +36,10 @@ export default function SuggestedQuestions({ onSelect }: Props) {
     <div className="flex flex-col items-center gap-6 px-3 py-8 sm:px-4 sm:py-12">
       <div className="text-center">
         <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-garmin-blue text-white sm:h-16 sm:w-16">
-          <GarminIcon />
+          <ActivityIcon />
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">Ask My Garmin</h2>
-        <p className="mt-1 text-sm text-gray-500">
+        <h2 className="text-xl font-semibold text-garmin-text">Ask My Garmin</h2>
+        <p className="mt-1 text-sm text-garmin-text-muted">
           Get personalized training insights from your Garmin data using AI.
         </p>
       </div>
@@ -49,7 +49,7 @@ export default function SuggestedQuestions({ onSelect }: Props) {
           <button
             key={q}
             onClick={() => onSelect(q)}
-            className="rounded-xl border border-gray-200 bg-white px-3 py-3 text-left text-sm text-gray-700 shadow-sm transition-colors hover:border-garmin-blue hover:bg-blue-50 sm:px-4"
+            className="rounded-xl border border-garmin-border bg-garmin-surface px-3 py-3 text-left text-sm text-garmin-text shadow-sm transition-colors hover:border-garmin-blue hover:bg-garmin-surface-2 sm:px-4"
           >
             {q}
           </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,15 @@ const config: Config = {
       colors: {
         garmin: {
           blue: '#007DC3',
+          'blue-hover': '#0090DB',
           dark: '#1D2F3F',
+          bg: '#0F1923',
+          surface: '#1C2B3A',
+          'surface-2': '#243447',
+          border: '#2A3F55',
+          text: '#F2F7FB',
+          'text-muted': '#8FA8BF',
+          green: '#4BC56D',
         },
       },
     },


### PR DESCRIPTION
Implements the Garmin Connect dark UI style across the entire app as planned in issue #10.

## Changes
- Full dark color palette in Tailwind config (`garmin.bg`, `surface`, `surface-2`, `border`, `text`, `text-muted`, `green`)
- Font switched from Inter to Roboto (Garmin Connect’s primary web font)
- All components converted to dark theme: header, chat input, message bubbles, status indicator, suggestion cards, login modal
- Hero icon updated to activity/EKG waveform (fitness-relevant)
- Dark scrollbar styles

Closes #10

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the Garmin Connect dark UI across the app with a new Tailwind color palette and Roboto font for a consistent look and better readability. Addresses issue #10.

- **New Features**
  - Added full dark palette tokens to Tailwind (bg, surface, surface-2, border, text, text-muted, green, blue-hover).
  - Switched font to Roboto (weights 300/400/500/700).
  - Applied dark theme to header, chat input, message bubbles, status, suggested cards, and login modal.
  - Replaced hero icon with an activity/EKG waveform.
  - Styled dark scrollbars and updated MessageBubble test to expect the dark surface background.

<sup>Written for commit 47518df032aefcb4dd7f710748db1de23fa4c74a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

