### PR TITLE
fix: use heading level 2 selector in chat E2E tests

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -39,12 +39,14 @@ test('input is cleared after sending', async ({ page }) => {
 
 test('suggested questions disappear once a message is sent', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByText('Ask My Garmin').first()).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Ask My Garmin', level: 2 })).toBeVisible();
 
   await page.getByPlaceholder(/ask about your activities/i).fill('Hello');
   await page.getByRole('button', { name: /send/i }).click();
 
-  await expect(page.getByText('Ask My Garmin')).not.toBeVisible({ timeout: 5000 });
+  await expect(
+    page.getByRole('heading', { name: 'Ask My Garmin', level: 2 }),
+  ).not.toBeVisible({ timeout: 5000 });
 });
 
 test('Enter key submits the message', async ({ page }) => {
@@ -61,7 +63,7 @@ test('Shift+Enter does NOT submit the message', async ({ page }) => {
   await page.keyboard.press('Shift+Enter');
 
   // Suggested questions (empty state) should still be visible
-  await expect(page.getByText('Ask My Garmin').first()).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Ask My Garmin', level: 2 })).toBeVisible();
 });
 
 test('API error shows error message in chat', async ({ page }) => {


### PR DESCRIPTION
The 'suggested questions disappear once a message is sent' test used `page.getByText('Ask My Garmin')` which matched both the page header `<h1>` (always visible) and the SuggestedQuestions `<h2>` (hidden after first message). After sending a message, the h1 stayed visible, causing `not.toBeVisible()` to always fail.

Fix: use `getByRole('heading', { name: 'Ask My Garmin', level: 2 })` to exclusively target the SuggestedQuestions h2.

Closes #18

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix chat E2E tests by targeting the "Ask My Garmin" h2 with getByRole(level: 2) so visibility checks correctly reflect the SuggestedQuestions state after sending a message. Also update the Shift+Enter test to use the h2 selector, avoiding false positives from the header h1.

<sup>Written for commit 83099e75b951838704e4c11dc518b199cd8991d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

