### PR TITLE
fix: resolve E2E strict-mode violations in auth and heading locators

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -89,5 +89,5 @@ test('Fun Mode toggle switches to RunBot 9000 branding', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: /fun mode/i }).click();
 
-  await expect(page.getByRole('heading', { name: 'RunBot 9000' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'RunBot 9000', level: 1 })).toBeVisible();
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -16,7 +16,7 @@ test('app loads without errors', async ({ page }) => {
 
 test('shows app title in header', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Ask My Garmin' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Ask My Garmin', level: 1 })).toBeVisible();
 });
 
 test('shows suggested questions in empty state', async ({ page }) => {

--- a/src/components/GarminStatus.test.tsx
+++ b/src/components/GarminStatus.test.tsx
@@ -24,17 +24,17 @@ describe('GarminStatus', () => {
     expect(screen.getByText('(runner@example.com)')).toBeInTheDocument();
   });
 
-  it('shows "Not connected" and a Sign in button when disconnected', () => {
+  it('shows "Not connected" and a Connect button when disconnected', () => {
     render(<GarminStatus connected={false} onLoginClick={noop} onLogout={noop} />);
     expect(screen.getByText('Not connected')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /connect/i })).toBeInTheDocument();
   });
 
-  it('calls onLoginClick when Sign in is clicked', async () => {
+  it('calls onLoginClick when Connect is clicked', async () => {
     const user = userEvent.setup();
     const onLoginClick = vi.fn();
     render(<GarminStatus connected={false} onLoginClick={onLoginClick} onLogout={noop} />);
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.click(screen.getByRole('button', { name: /connect/i }));
     expect(onLoginClick).toHaveBeenCalledOnce();
   });
 

--- a/src/components/GarminStatus.tsx
+++ b/src/components/GarminStatus.tsx
@@ -52,7 +52,7 @@ export default function GarminStatus({ connected, email, onLoginClick, onLogout 
         onClick={onLoginClick}
         className="rounded-md bg-garmin-blue px-3 py-1 text-xs font-medium text-white transition-opacity hover:opacity-90"
       >
-        Sign in
+        Connect
       </button>
     </div>
   );


### PR DESCRIPTION
Closes #20

Two separate bugs caused 8 nightly E2E failures:

1. **Duplicate "Sign in" buttons**: when the login modal was open while disconnected, both GarminStatus's header button and LoginModal's form button matched `/sign in/i`, causing Playwright's strict-mode `.click()` to throw "resolved to 2 elements". Fix: rename the header button from "Sign in" to "Connect".

2. **Ambiguous heading locators**: both `<h1>` (page header) and `<h2>` (SuggestedQuestions) render the same text, so `getByRole('heading', { name })` matched multiple elements. Fix: add `level: 1` to target the header `<h1>` specifically.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Playwright strict-mode E2E failures by renaming the disconnected header button to “Connect” and scoping heading locators to level 1. This prevents duplicate matches for “Sign in” and ambiguous heading selectors.

- **Bug Fixes**
  - Auth: Rename GarminStatus header button from “Sign in” to “Connect” to avoid duplicate matches with the LoginModal when disconnected.
  - Tests: Add level: 1 to heading expectations in smoke/chat specs to target the page <h1> and avoid multiple matches.

<sup>Written for commit 3db08f3180b121d013b89d4809fe71afd7f181c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

