### PR TITLE
fix: prevent mobile zoom on chat input

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -158,7 +158,7 @@ export default function ChatInterface({
             placeholder="Ask about your activities, sleep, heart rate…"
             rows={1}
             disabled={isStreaming}
-            className={`max-h-32 flex-1 resize-none overflow-y-auto rounded-xl border border-garmin-border bg-garmin-bg px-4 py-3 text-sm text-garmin-text placeholder:text-garmin-text-muted focus:border-transparent focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50 ${accentFocus}`}
+            className={`max-h-32 flex-1 resize-none overflow-y-auto rounded-xl border border-garmin-border bg-garmin-bg px-4 py-3 text-base text-garmin-text placeholder:text-garmin-text-muted focus:border-transparent focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50 ${accentFocus}`}
             style={{ minHeight: '44px' }}
             onInput={(e) => {
               const el = e.currentTarget;


### PR DESCRIPTION
iOS/Android zoom in automatically on inputs with font-size < 16px. Changed textarea from `text-sm` (14px) to `text-base` (16px) to prevent the unwanted zoom when tapping the chat input on mobile.

Closes #22

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent unwanted mobile zoom on the chat input by increasing the textarea font size to 16px (text-base). iOS/Android auto-zoom inputs under 16px; this fixes #22.

<sup>Written for commit d921d6edf598a47dad0c7689f55a7df84ed3ce6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

