### PR TITLE
Add markdown rendering, tables and chart blocks for agent responses

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -445,6 +445,9 @@ or "Your HRV is frankly concerning and you should probably run through it anyway
 
 Keep answers genuinely helpful but entertainingly unhinged. The humor comes from the gap between \
 the absurdity of the framing and the genuine usefulness of the data.
+
+Use Markdown formatting: **bold** key stats, use tables for comparing multiple runs, and emit \
+```chart blocks for 3+ data points. Do NOT use H1 headings.
 Today's date: {today}.
 
 ## User's Garmin Data
@@ -624,11 +627,30 @@ These are facts you do not soften or both-sides:
 ---
 
 <output_format>
-- Use plain text; avoid markdown headers (the chat UI does not render them).
+FORMATTING RULES — the chat UI renders Markdown:
+- Use Markdown in all responses. Bold key numbers and terms with **text**.
+- Do NOT use H1 headings. Use ## or ### for sections if needed.
+- For lists of activities or metrics (2+ items): use a GFM pipe table with a header row.
+- For a single stat or short answer: plain prose with **bold** highlights is preferred.
+- For time-series data with 3+ comparable data points: emit a ```chart block using the schema below.
 - Express distances in miles unless the athlete asks for km.
 - Express durations in hours and minutes, not decimal hours.
 - When referencing heart rate zones, use the athlete's actual zone boundaries from their data.
 - Today's date: {today}.
+
+CHART SCHEMA — only emit a ```chart block when there are 3+ data points:
+```
+{{
+  "type": "bar" | "line" | "doughnut",
+  "title": "optional title string",
+  "labels": ["label1", "label2", ...],
+  "datasets": [{{ "label": "series name", "data": [number, number, ...] }}]
+}}
+```
+Example (weekly mileage bar chart):
+```chart
+{{"type":"bar","title":"Weekly Distance (mi)","labels":["Week 1","Week 2","Week 3"],"datasets":[{{"label":"miles","data":[32,28,41]}}]}}
+```
 </output_format>
 
 ## Athlete's Garmin Data

--- a/src/components/ChartBlock.test.tsx
+++ b/src/components/ChartBlock.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ChartBlock from './ChartBlock';
+
+const validBarChart = JSON.stringify({
+  type: 'bar',
+  title: 'Weekly Distance (mi)',
+  labels: ['Week 1', 'Week 2', 'Week 3'],
+  datasets: [{ label: 'miles', data: [32, 28, 41] }],
+});
+
+const validLineChart = JSON.stringify({
+  type: 'line',
+  title: 'Pace Trend',
+  labels: ['Mon', 'Wed', 'Fri'],
+  datasets: [{ label: 'pace', data: [525, 540, 512] }],
+});
+
+const validDoughnutChart = JSON.stringify({
+  type: 'doughnut',
+  title: 'Activity Mix',
+  labels: ['Run', 'Bike', 'Swim'],
+  datasets: [{ label: 'count', data: [15, 5, 3] }],
+});
+
+describe('ChartBlock', () => {
+  describe('bar chart', () => {
+    it('renders the chart title', () => {
+      render(<ChartBlock content={validBarChart} />);
+      expect(screen.getByText('Weekly Distance (mi)')).toBeInTheDocument();
+    });
+
+    it('renders all labels', () => {
+      render(<ChartBlock content={validBarChart} />);
+      expect(screen.getByText('Week 1')).toBeInTheDocument();
+      expect(screen.getByText('Week 2')).toBeInTheDocument();
+      expect(screen.getByText('Week 3')).toBeInTheDocument();
+    });
+
+    it('renders data values', () => {
+      render(<ChartBlock content={validBarChart} />);
+      expect(screen.getByText('32')).toBeInTheDocument();
+      expect(screen.getByText('28')).toBeInTheDocument();
+      expect(screen.getByText('41')).toBeInTheDocument();
+    });
+
+    it('does not render a <pre> fallback for valid data', () => {
+      const { container } = render(<ChartBlock content={validBarChart} />);
+      expect(container.querySelector('pre')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('line chart (table fallback)', () => {
+    it('renders title and a data table', () => {
+      render(<ChartBlock content={validLineChart} />);
+      expect(screen.getByText('Pace Trend')).toBeInTheDocument();
+      const { container } = render(<ChartBlock content={validLineChart} />);
+      expect(container.querySelector('table')).toBeInTheDocument();
+    });
+
+    it('shows all labels in the table', () => {
+      render(<ChartBlock content={validLineChart} />);
+      expect(screen.getAllByText('Mon').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('doughnut chart (table fallback)', () => {
+    it('renders a table with labels and values', () => {
+      const { container } = render(<ChartBlock content={validDoughnutChart} />);
+      expect(container.querySelector('table')).toBeInTheDocument();
+      expect(screen.getByText('Activity Mix')).toBeInTheDocument();
+    });
+  });
+
+  describe('error handling', () => {
+    it('falls back to <pre> on malformed JSON', () => {
+      const { container } = render(<ChartBlock content="{invalid json" />);
+      expect(container.querySelector('pre')).toBeInTheDocument();
+      expect(screen.getByText('{invalid json')).toBeInTheDocument();
+    });
+
+    it('falls back to <pre> when JSON has invalid shape (missing type)', () => {
+      const bad = JSON.stringify({ labels: ['A', 'B'], datasets: [] });
+      const { container } = render(<ChartBlock content={bad} />);
+      expect(container.querySelector('pre')).toBeInTheDocument();
+    });
+
+    it('falls back to <pre> when JSON has invalid type value', () => {
+      const bad = JSON.stringify({ type: 'pie', labels: ['A'], datasets: [] });
+      const { container } = render(<ChartBlock content={bad} />);
+      expect(container.querySelector('pre')).toBeInTheDocument();
+    });
+
+    it('does not throw when datasets have missing data points', () => {
+      const sparse = JSON.stringify({
+        type: 'bar',
+        labels: ['A', 'B', 'C'],
+        datasets: [{ label: 'val', data: [10] }], // missing data for B and C
+      });
+      expect(() => render(<ChartBlock content={sparse} />)).not.toThrow();
+    });
+  });
+});

--- a/src/components/ChartBlock.tsx
+++ b/src/components/ChartBlock.tsx
@@ -1,0 +1,151 @@
+/**
+ * ChartBlock renders a structured chart from a JSON payload emitted by Claude
+ * inside a fenced ```chart code block.
+ *
+ * Expected JSON shape:
+ *   { type: "bar"|"line"|"doughnut", title?: string,
+ *     labels: string[], datasets: [{ label: string, data: number[] }] }
+ *
+ * Bar charts are rendered as proportional CSS bars.
+ * Line and doughnut types fall back to a readable data table.
+ * Any malformed JSON renders as a plain code block (no crash).
+ */
+import type { ChartData } from '@/types';
+
+function isChartData(obj: unknown): obj is ChartData {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    (o.type === 'bar' || o.type === 'line' || o.type === 'doughnut') &&
+    Array.isArray(o.labels) &&
+    Array.isArray(o.datasets)
+  );
+}
+
+const COLORS = ['#007DC3', '#4BC56D', '#FF6B35', '#8FA8BF'] as const;
+
+type Color = (typeof COLORS)[number];
+
+function getColor(index: number): Color {
+  return COLORS[index % COLORS.length] ?? COLORS[0];
+}
+
+interface ChartBlockProps {
+  content: string;
+}
+
+export default function ChartBlock({ content }: ChartBlockProps) {
+  let data: ChartData;
+
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!isChartData(parsed)) throw new Error('Invalid chart shape');
+    data = parsed;
+  } catch {
+    // Graceful fallback — render raw JSON as a plain code block
+    return (
+      <pre className="mb-2 overflow-x-auto rounded-lg bg-garmin-bg p-3 font-mono text-sm text-garmin-text">
+        {content}
+      </pre>
+    );
+  }
+
+  // Transform labels + datasets into rows: [{ name, [dsLabel]: value }]
+  const rows = data.labels.map((label, i) => {
+    const entry: Record<string, string | number> = { name: label };
+    for (const ds of data.datasets) {
+      entry[ds.label] = ds.data[i] ?? 0;
+    }
+    return entry;
+  });
+
+  const allValues = data.datasets.flatMap((ds) => ds.data);
+  const maxValue = Math.max(...allValues, 1);
+
+  if (data.type === 'bar') {
+    return (
+      <div className="mb-2 rounded-lg border border-garmin-border bg-garmin-surface p-4">
+        {data.title && (
+          <p className="mb-3 text-sm font-semibold text-garmin-text">{data.title}</p>
+        )}
+        <div className="space-y-3">
+          {rows.map((row, ri) => (
+            <div key={ri} className="flex items-start gap-3 text-xs">
+              <span className="w-20 shrink-0 pt-0.5 text-right text-garmin-text-muted">
+                {row.name}
+              </span>
+              <div className="flex-1 space-y-1">
+                {data.datasets.map((ds, di) => {
+                  const val = ds.data[ri] ?? 0;
+                  const pct = Math.round((val / maxValue) * 100);
+                  const color = getColor(di);
+                  return (
+                    <div key={ds.label} className="flex items-center gap-2">
+                      <div
+                        className="h-4 rounded"
+                        style={{
+                          width: `${pct}%`,
+                          minWidth: val > 0 ? '4px' : '0',
+                          backgroundColor: color,
+                        }}
+                      />
+                      <span className="text-garmin-text-muted">{val}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+        {data.datasets.length > 1 && (
+          <div className="mt-3 flex flex-wrap gap-3">
+            {data.datasets.map((ds, di) => (
+              <div key={ds.label} className="flex items-center gap-1 text-xs text-garmin-text-muted">
+                <div
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: getColor(di) }}
+                />
+                {ds.label}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Line and doughnut — render as a structured table (readable without a canvas library)
+  return (
+    <div className="mb-2 rounded-lg border border-garmin-border bg-garmin-surface p-4">
+      {data.title && (
+        <p className="mb-3 text-sm font-semibold text-garmin-text">{data.title}</p>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b border-garmin-border">
+              <th className="pb-2 pr-4 text-left font-medium text-garmin-text-muted">Label</th>
+              {data.datasets.map((ds) => (
+                <th key={ds.label} className="pb-2 pr-4 text-left font-medium text-garmin-text-muted">
+                  {ds.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, ri) => (
+              <tr key={ri} className="border-b border-garmin-border last:border-0">
+                <td className="py-1 pr-4 text-garmin-text">{row.name}</td>
+                {data.datasets.map((ds) => (
+                  <td key={ds.label} className="py-1 pr-4 text-garmin-text-muted">
+                    {ds.data[ri] ?? 0}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MessageBubble.test.tsx
+++ b/src/components/MessageBubble.test.tsx
@@ -60,4 +60,68 @@ describe('MessageBubble', () => {
     );
     expect(container.querySelector('.bg-garmin-surface')).toBeInTheDocument();
   });
+
+  // ── Markdown rendering ──────────────────────────────────────────────────────
+
+  it('renders bold markdown as <strong> in assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: '**Training Readiness**: 72' }} />
+    );
+    const strong = container.querySelector('strong');
+    expect(strong).toBeInTheDocument();
+    expect(strong).toHaveTextContent('Training Readiness');
+  });
+
+  it('does not render markdown in user messages (plain text)', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'user', content: '**bold**' }} />
+    );
+    // User messages are plain text — no <strong> element
+    expect(container.querySelector('strong')).not.toBeInTheDocument();
+    expect(screen.getByText('**bold**')).toBeInTheDocument();
+  });
+
+  it('renders a GFM table for assistant messages', () => {
+    const tableMarkdown = `| Date | Distance |
+|------|----------|
+| Feb 28 | 10.2 mi |
+| Mar 1 | 6.5 mi |`;
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: tableMarkdown }} />
+    );
+    expect(container.querySelector('table')).toBeInTheDocument();
+    expect(container.querySelector('thead')).toBeInTheDocument();
+    expect(screen.getByText('Date')).toBeInTheDocument();
+    expect(screen.getByText('10.2 mi')).toBeInTheDocument();
+  });
+
+  it('renders headings for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: '## Training Summary' }} />
+    );
+    const h2 = container.querySelector('h2');
+    expect(h2).toBeInTheDocument();
+    expect(h2).toHaveTextContent('Training Summary');
+  });
+
+  it('renders unordered lists for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble
+        message={{ role: 'assistant', content: '- Run easy\n- Sleep 8 hours\n- Hydrate' }}
+      />
+    );
+    const list = container.querySelector('ul');
+    expect(list).toBeInTheDocument();
+    expect(container.querySelectorAll('li')).toHaveLength(3);
+  });
+
+  it('renders code blocks for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble
+        message={{ role: 'assistant', content: '```python\nprint("hello")\n```' }}
+      />
+    );
+    expect(container.querySelector('pre')).toBeInTheDocument();
+    expect(screen.getByText('print("hello")')).toBeInTheDocument();
+  });
 });

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,3 +1,6 @@
+import type { ReactNode } from 'react';
+import { parseMarkdownBlocks, renderBlock } from '@/lib/markdown';
+import ChartBlock from './ChartBlock';
 import type { Message } from '@/types';
 
 interface Props {
@@ -16,6 +19,34 @@ function GarminIcon() {
         strokeLinejoin="round"
       />
     </svg>
+  );
+}
+
+function renderCodeBlock(language: string, content: string, key: number): ReactNode {
+  if (language === 'chart') {
+    return <ChartBlock key={key} content={content} />;
+  }
+  return (
+    <pre
+      key={key}
+      className="mb-2 overflow-x-auto rounded-lg bg-garmin-bg p-3 font-mono text-sm text-garmin-text"
+    >
+      <code>{content}</code>
+    </pre>
+  );
+}
+
+function AssistantContent({ content }: { content: string }) {
+  const blocks = parseMarkdownBlocks(content);
+
+  if (blocks.length === 0) {
+    return <span className="text-garmin-text-muted">…</span>;
+  }
+
+  return (
+    <div>
+      {blocks.map((block, i) => renderBlock(block, i, { renderCode: renderCodeBlock }))}
+    </div>
   );
 }
 
@@ -45,10 +76,13 @@ export default function MessageBubble({ message, isStreaming = false }: Props) {
             <span className="h-2 w-2 animate-bounce rounded-full bg-garmin-text-muted [animation-delay:-0.15s]" />
             <span className="h-2 w-2 animate-bounce rounded-full bg-garmin-text-muted" />
           </span>
-        ) : (
+        ) : isUser ? (
           <span className="whitespace-pre-wrap">{message.content || '…'}</span>
+        ) : (
+          <AssistantContent content={message.content} />
         )}
       </div>
     </div>
   );
 }
+

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -1,0 +1,341 @@
+/**
+ * Lightweight, zero-dependency Markdown renderer for assistant messages.
+ * Handles: headings, paragraphs, bold, italic, inline code, fenced code blocks,
+ * GFM tables, ordered/unordered lists, blockquotes, and horizontal rules.
+ * Chart code blocks (```chart) are delegated to ChartBlock via the `renderCode` prop.
+ */
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type HeadingBlock = { kind: 'heading'; level: 1 | 2 | 3; text: string };
+type ParagraphBlock = { kind: 'paragraph'; lines: string[] };
+type HrBlock = { kind: 'hr' };
+type CodeBlock = { kind: 'code'; language: string; content: string };
+type TableBlock = { kind: 'table'; headers: string[]; rows: string[][] };
+type ListBlock = { kind: 'list'; ordered: boolean; items: string[] };
+type BlockquoteBlock = { kind: 'blockquote'; lines: string[] };
+
+type Block =
+  | HeadingBlock
+  | ParagraphBlock
+  | HrBlock
+  | CodeBlock
+  | TableBlock
+  | ListBlock
+  | BlockquoteBlock;
+
+// ── Inline parser ─────────────────────────────────────────────────────────────
+
+/** Render inline Markdown (bold, italic, inline code, links) as React nodes. */
+export function renderInline(text: string): ReactNode {
+  // Split on inline markers — order matters: ** before *
+  const segments = text.split(
+    /(\*\*[^*\n]+\*\*|__[^_\n]+__|\*[^*\n]+\*|_[^_\n]+_|`[^`\n]+`|\[[^\]\n]+\]\([^)\n]+\))/
+  );
+
+  if (segments.length === 1) return text;
+
+  return (
+    <>
+      {segments.map((seg, i) => {
+        if (seg.startsWith('**') && seg.endsWith('**') && seg.length > 4) {
+          return (
+            <strong key={i} className="font-semibold text-white">
+              {seg.slice(2, -2)}
+            </strong>
+          );
+        }
+        if (seg.startsWith('__') && seg.endsWith('__') && seg.length > 4) {
+          return (
+            <strong key={i} className="font-semibold text-white">
+              {seg.slice(2, -2)}
+            </strong>
+          );
+        }
+        if (seg.startsWith('`') && seg.endsWith('`') && seg.length > 2) {
+          return (
+            <code
+              key={i}
+              className="rounded bg-garmin-bg px-1 py-0.5 font-mono text-sm text-garmin-text"
+            >
+              {seg.slice(1, -1)}
+            </code>
+          );
+        }
+        if (seg.startsWith('*') && seg.endsWith('*') && seg.length > 2 && !seg.startsWith('**')) {
+          return (
+            <em key={i} className="italic">
+              {seg.slice(1, -1)}
+            </em>
+          );
+        }
+        if (seg.startsWith('_') && seg.endsWith('_') && seg.length > 2 && !seg.startsWith('__')) {
+          return (
+            <em key={i} className="italic">
+              {seg.slice(1, -1)}
+            </em>
+          );
+        }
+        const lm = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(seg);
+        if (lm) {
+          return (
+            <a
+              key={i}
+              href={lm[2]}
+              className="text-garmin-blue underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {lm[1]}
+            </a>
+          );
+        }
+        return seg || null;
+      })}
+    </>
+  );
+}
+
+// ── Block parser ──────────────────────────────────────────────────────────────
+
+function parseRow(line: string): string[] {
+  return line
+    .split('|')
+    .slice(1, -1)
+    .map((c) => c.trim());
+}
+
+function isTableSeparator(line: string): boolean {
+  return /^\|[\s\-:|]+\|/.test(line);
+}
+
+function isParagraphLine(line: string): boolean {
+  return (
+    line.trim() !== '' &&
+    !/^#{1,3}\s/.test(line) &&
+    !line.startsWith('```') &&
+    !line.startsWith('|') &&
+    !/^[-*+]\s/.test(line) &&
+    !/^\d+\.\s/.test(line) &&
+    !line.startsWith('> ') &&
+    !/^[-*_]{3,}$/.test(line.trim())
+  );
+}
+
+/** Parse Markdown content into a flat list of typed blocks. */
+export function parseMarkdownBlocks(content: string): Block[] {
+  const lines = content.split('\n');
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Empty line
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Heading (H1–H3)
+    const hm = /^(#{1,3})\s+(.+)$/.exec(line);
+    if (hm) {
+      const rawLevel = hm[1].length;
+      const level: 1 | 2 | 3 = rawLevel === 1 ? 1 : rawLevel === 2 ? 2 : 3;
+      blocks.push({ kind: 'heading', level, text: hm[2] });
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^[-*_]{3,}$/.test(line.trim())) {
+      blocks.push({ kind: 'hr' });
+      i++;
+      continue;
+    }
+
+    // Fenced code block
+    if (line.startsWith('```')) {
+      const language = line.slice(3).trim();
+      i++;
+      const codeLines: string[] = [];
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      if (i < lines.length) i++; // consume closing ```
+      blocks.push({ kind: 'code', language, content: codeLines.join('\n') });
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith('> ')) {
+      const bqLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith('> ')) {
+        bqLines.push(lines[i].slice(2));
+        i++;
+      }
+      blocks.push({ kind: 'blockquote', lines: bqLines });
+      continue;
+    }
+
+    // GFM Table
+    if (line.startsWith('|')) {
+      const headers = parseRow(line);
+      i++;
+      if (i < lines.length && isTableSeparator(lines[i])) i++;
+      const rows: string[][] = [];
+      while (i < lines.length && lines[i].startsWith('|')) {
+        rows.push(parseRow(lines[i]));
+        i++;
+      }
+      blocks.push({ kind: 'table', headers, rows });
+      continue;
+    }
+
+    // Unordered list
+    if (/^[-*+]\s/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[-*+]\s/.test(lines[i])) {
+        items.push(lines[i].slice(2));
+        i++;
+      }
+      blocks.push({ kind: 'list', ordered: false, items });
+      continue;
+    }
+
+    // Ordered list
+    if (/^\d+\.\s/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\d+\.\s/.test(lines[i])) {
+        items.push(lines[i].replace(/^\d+\.\s+/, ''));
+        i++;
+      }
+      blocks.push({ kind: 'list', ordered: true, items });
+      continue;
+    }
+
+    // Paragraph — collect consecutive non-special lines
+    const paraLines: string[] = [];
+    while (i < lines.length && isParagraphLine(lines[i])) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      blocks.push({ kind: 'paragraph', lines: paraLines });
+    }
+  }
+
+  return blocks;
+}
+
+// ── Block renderer ─────────────────────────────────────────────────────────────
+
+interface RenderOptions {
+  /** Called for fenced code blocks so the consumer can handle 'chart' language. */
+  renderCode: (language: string, content: string, key: number) => ReactNode;
+}
+
+export function renderBlock(block: Block, index: number, opts: RenderOptions): ReactNode {
+  switch (block.kind) {
+    case 'heading': {
+      const cls = 'mb-2 font-semibold text-garmin-text';
+      if (block.level === 1)
+        return (
+          <h1 key={index} className={`${cls} text-xl`}>
+            {renderInline(block.text)}
+          </h1>
+        );
+      if (block.level === 2)
+        return (
+          <h2 key={index} className={`${cls} text-lg`}>
+            {renderInline(block.text)}
+          </h2>
+        );
+      return (
+        <h3 key={index} className={`${cls} text-base`}>
+          {renderInline(block.text)}
+        </h3>
+      );
+    }
+
+    case 'paragraph':
+      return (
+        <p key={index} className="mb-2 last:mb-0">
+          {block.lines.map((line, li) => (
+            <Fragment key={li}>
+              {li > 0 && <br />}
+              {renderInline(line)}
+            </Fragment>
+          ))}
+        </p>
+      );
+
+    case 'hr':
+      return <hr key={index} className="my-3 border-garmin-border" />;
+
+    case 'code':
+      return opts.renderCode(block.language, block.content, index);
+
+    case 'table':
+      return (
+        <div key={index} className="mb-2 overflow-x-auto">
+          <table className="min-w-full border border-garmin-border text-sm">
+            <thead className="bg-garmin-surface-2">
+              <tr>
+                {block.headers.map((h, hi) => (
+                  <th key={hi} className="px-3 py-2 text-left font-semibold text-garmin-text">
+                    {renderInline(h)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {block.rows.map((row, ri) => (
+                <tr key={ri} className="border-b border-garmin-border last:border-0">
+                  {row.map((cell, ci) => (
+                    <td key={ci} className="px-3 py-2 text-garmin-text-muted">
+                      {renderInline(cell)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+
+    case 'list': {
+      const Tag = block.ordered ? 'ol' : 'ul';
+      const cls = block.ordered
+        ? 'mb-2 list-inside list-decimal space-y-1 pl-2'
+        : 'mb-2 list-inside list-disc space-y-1 pl-2';
+      return (
+        <Tag key={index} className={cls}>
+          {block.items.map((item, ii) => (
+            <li key={ii} className="text-garmin-text">
+              {renderInline(item)}
+            </li>
+          ))}
+        </Tag>
+      );
+    }
+
+    case 'blockquote':
+      return (
+        <blockquote
+          key={index}
+          className="mb-2 border-l-2 border-garmin-blue pl-3 italic text-garmin-text-muted"
+        >
+          {block.lines.map((line, li) => (
+            <Fragment key={li}>
+              {li > 0 && <br />}
+              {renderInline(line)}
+            </Fragment>
+          ))}
+        </blockquote>
+      );
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,15 @@ export interface Message {
   role: 'user' | 'assistant';
   content: string;
 }
+
+export interface ChartDataset {
+  label: string;
+  data: number[];
+}
+
+export interface ChartData {
+  type: 'bar' | 'line' | 'doughnut';
+  title?: string;
+  labels: string[];
+  datasets: ChartDataset[];
+}


### PR DESCRIPTION
Implements rich formatting for the assistant response bubble: Markdown rendering, GFM tables, and a ```chart``` code block protocol for inline data visualisation.

Closes #24

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render assistant messages with Markdown, including GFM tables and inline chart blocks, to make data easier to scan. Adds a tiny zero-dependency renderer and a ChartBlock, plus prompt updates so responses use the new format.

- **New Features**
  - Markdown for assistant messages: headings (H2/H3), bold/italic, inline/code blocks, lists, blockquotes, and tables; user messages stay plain text.
  - Chart blocks: parse fenced chart JSON; render bar charts as proportional CSS bars, line/doughnut as readable tables; fall back to a plain code block on bad JSON.
  - MessageBubble integrates the renderer and ChartBlock while keeping the streaming UI.
  - Backend prompt now instructs Markdown (no H1), prefers GFM tables for multi-item comparisons, and includes a chart schema for 3+ data points; adds ChartData types and tests.

<sup>Written for commit 69088d118aa5a8c2464dc8ce7f88d919a2a1d22d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

