### PR TITLE
Add spec-driven development and TDD workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,51 @@
 - Zero context switching required from the user
 - Go fix failing CI tests without being told how
 
+## Spec-Driven Development (SDD)
+
+Every non-trivial feature or change **must start with a written spec**. Specs are persisted
+in the `specs/` directory and serve as the single source of truth throughout development.
+
+### Spec lifecycle
+
+1. **Draft spec** — Write `specs/features/<kebab-case-name>.md` using `specs/template.md`
+   _before_ touching any code.
+2. **Acceptance criteria first** — Define exactly what "done" looks like before designing a
+   solution.
+3. **Technical design** — Describe data shapes, component interactions, and API contracts.
+4. **Commit the spec** — The spec must be committed and visible (status: `ready`) before
+   implementation starts.
+5. **Update status** — Track progress via the `status:` field in each spec:
+   `draft` → `ready` → `in-progress` → `done`
+
+### Test-Driven Development (TDD)
+
+Once the spec is `ready`, follow the **Red → Green → Refactor** cycle strictly:
+
+1. **Red** — Write failing tests that encode every acceptance criterion from the spec.
+2. **Green** — Write the minimum implementation to make the tests pass.
+3. **Refactor** — Clean up code and types while keeping tests green.
+
+**No spec → no tests → no implementation code.** This is a hard rule, not a suggestion.
+
+### What counts as "non-trivial"
+
+- Any new component, route, or library function
+- Any change to data shapes or API contracts
+- Any change to the Claude system prompt
+- Any UI flow that has more than one state
+
+Simple one-line fixes and typo corrections do not need a spec.
+
 ## Task Management
 
-1. **Plan First**: Write plan to 'tasks/todo.md' with checkable items
-2. **Verify Plan**: Check in before starting implementation
-3. **Track Progress**: Mark items complete as you go
-4. **Explain Changes**: High-level summary at each step
-5. **Document Results**: Add review to 'tasks/todo.md'
-6. **Capture Lessons**: Update 'tasks/lessons.md' after corrections
+1. **Spec First**: Write spec to `specs/features/<name>.md`, set status to `ready`
+2. **Plan**: Write plan to 'tasks/todo.md' with checkable items tied to spec ACs
+3. **Test First (TDD)**: Write failing tests before implementation
+4. **Implement**: Make tests pass with minimum code
+5. **Verify**: Run full CI suite; all checks must pass
+6. **Mark Done**: Update spec status to `done`, mark todos complete
+7. **Capture Lessons**: Update 'tasks/lessons.md' after corrections
 
 ## Core Principles
 
@@ -153,6 +190,14 @@ src/
 
 Tests live next to source files: `src/components/Foo.test.tsx`, `src/lib/foo.test.ts`.
 
+**TDD order (mandatory for non-trivial code):**
+
+1. Write tests derived from the spec's acceptance criteria — they should fail.
+2. Implement the feature — make them pass.
+3. Refactor — keep them green.
+
+Every acceptance criterion in a spec maps to at least one test case.
+
 **What to test:**
 
 - All pure utility functions in `src/lib/` (no mocking needed — just import and assert)
@@ -179,8 +224,8 @@ import { server } from '@/test/msw/server';
 server.use(http.get('/api/garmin/status', () => HttpResponse.json({ connected: false })));
 ```
 
-Coverage thresholds (enforced in CI): **60% lines / functions / branches**.
-The bar rises as the codebase grows — keep new code tested.
+Coverage thresholds (enforced in CI): **80% lines / functions / branches**.
+New code must meet this bar — do not lower it.
 
 ## Git hooks (Husky)
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,56 @@
+# Specs — Ask My Garmin
+
+This directory contains feature specs for the project. Specs are the **source of truth** for
+what gets built and why. No implementation code is written without a corresponding spec.
+
+## Directory layout
+
+```
+specs/
+  README.md          ← You are here
+  template.md        ← Blank spec template — copy this for every new feature
+  features/          ← One file per feature (active, in-progress, or done)
+```
+
+## Spec lifecycle
+
+| Status        | Meaning                                                         |
+| ------------- | --------------------------------------------------------------- |
+| `draft`       | Being written — not ready for implementation                    |
+| `ready`       | Acceptance criteria are finalized — tests can be written        |
+| `in-progress` | TDD cycle underway — tests written, implementation in progress  |
+| `done`        | All acceptance criteria pass, PR merged                         |
+
+## Workflow
+
+1. **Create a spec** by copying `template.md` → `features/<kebab-case-name>.md`.
+2. Fill in every section. Set `status: ready` when acceptance criteria are complete.
+3. Commit the spec before writing any test or implementation code.
+4. Write **failing tests** that encode each numbered acceptance criterion (TDD Red).
+5. Write the minimum code to make the tests pass (TDD Green).
+6. Refactor while keeping tests green.
+7. Update `status: done` in the spec and include it in the same PR.
+
+## Naming conventions
+
+- File names use lowercase kebab-case: `garmin-data-sources.md`, `chat-streaming.md`.
+- Acceptance criteria are numbered (AC-1, AC-2, …) and referenced in test `describe`/`it`
+  blocks so reviewers can trace code back to requirements.
+
+## Example acceptance criterion → test mapping
+
+Spec:
+```
+### Acceptance criteria
+
+- AC-1: The status indicator shows "Connected" when `/api/garmin/status` returns `{ connected: true }`.
+- AC-2: The status indicator shows "Disconnected" when the endpoint returns `{ connected: false }`.
+```
+
+Test:
+```tsx
+describe('GarminStatus', () => {
+  it('AC-1: shows Connected when status endpoint returns connected: true', async () => { ... });
+  it('AC-2: shows Disconnected when status endpoint returns connected: false', async () => { ... });
+});
+```

--- a/specs/template.md
+++ b/specs/template.md
@@ -1,0 +1,77 @@
+---
+title: <Feature Name>
+status: draft   # draft | ready | in-progress | done
+issue: "#<issue-number>"
+pr: ""
+created: YYYY-MM-DD
+---
+
+# <Feature Name>
+
+## Problem statement
+
+<!-- Why does this feature need to exist? What user pain or gap does it address? -->
+
+## Goals
+
+<!-- What will be true when this feature is done? (outcomes, not tasks) -->
+
+-
+
+## Non-goals
+
+<!-- What is explicitly out of scope for this spec? -->
+
+-
+
+## Acceptance criteria
+
+<!-- Numbered, testable statements. Each maps to ≥1 test case.
+     Format: "AC-N: Given <context>, when <action>, then <outcome>."  -->
+
+- AC-1:
+- AC-2:
+
+## Technical design
+
+### Data shapes / types
+
+<!-- New or changed TypeScript interfaces (add to src/types/index.ts) -->
+
+```ts
+// example
+```
+
+### Components / routes affected
+
+<!-- List files that will be created or modified -->
+
+| File | Change |
+| ---- | ------ |
+|      |        |
+
+### Data flow
+
+<!-- Describe the sequence of events (user action → API call → state update → render) -->
+
+1.
+2.
+
+## Test scenarios
+
+<!-- Derived from acceptance criteria. List all unit + integration test cases. -->
+
+| ID   | Description                        | Type        | AC refs |
+| ---- | ---------------------------------- | ----------- | ------- |
+| T-1  |                                    | unit        | AC-1    |
+| T-2  |                                    | integration | AC-2    |
+
+## Open questions
+
+<!-- Decisions still to be made. Remove this section when all are resolved. -->
+
+-
+
+## Implementation notes
+
+<!-- Added after implementation: key decisions made, gotchas encountered. -->

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,9 +30,9 @@ export default defineConfig({
         'src/app/globals.css',
       ],
       thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 60,
+        lines: 80,
+        functions: 80,
+        branches: 80,
       },
     },
   },


### PR DESCRIPTION
Add spec-driven development (SDD) and test-driven development (TDD) workflow to agent instructions and project configuration.

- New `## Spec-Driven Development` section in CLAUDE.md with lifecycle, TDD Red/Green/Refactor cycle, and hard rule: no spec → no tests → no code
- Updated Task Management order: spec first, then tests, then implementation
- Coverage thresholds raised from 60% → 80% in vitest.config.ts and docs
- New SDD+TDD workflow section in AGENTS.md for any agent working in this repo
- `specs/README.md` documents process, lifecycle, and AC→test mapping
- `specs/template.md` blank template for all future feature specs

Closes #30

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a spec-first, test-driven workflow across the repo and enforce 80% test coverage to improve reliability and traceability. Implements the spec-driven process requested in #30.

- **New Features**
  - Spec-Driven Development in CLAUDE.md with lifecycle and strict “no spec → no tests → no code”.
  - TDD Red/Green/Refactor formalized; testing conventions updated.
  - AGENTS.md: new SDD+TDD workflow, full CI check order, and updated commands.
  - New specs/README.md and specs/template.md for feature specs.
  - Vitest coverage thresholds raised to 80% (lines/functions/branches).

- **Migration**
  - For any non-trivial change, create specs/features/<name>.md from the template, set status to ready, and commit it first.
  - Write failing tests for each acceptance criterion, then implement, then refactor.
  - PRs must pass: format:check, lint (zero warnings), typecheck, test:run (≥80% coverage), build.
  - One-line fixes can skip specs.

<sup>Written for commit f890974378b5a5ef4ca3da55be14e66fcb381a95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

