### PR TITLE
test: expand test suite with 61 new tests

### DIFF
--- a/src/components/ChartBlock.test.tsx
+++ b/src/components/ChartBlock.test.tsx
@@ -100,4 +100,81 @@ describe('ChartBlock', () => {
       expect(() => render(<ChartBlock content={sparse} />)).not.toThrow();
     });
   });
+
+  describe('chart without a title', () => {
+    it('renders a bar chart without crashing when title is omitted', () => {
+      const noTitle = JSON.stringify({
+        type: 'bar',
+        labels: ['A', 'B'],
+        datasets: [{ label: 'val', data: [10, 20] }],
+      });
+      render(<ChartBlock content={noTitle} />);
+      expect(screen.getByText('10')).toBeInTheDocument();
+      expect(screen.getByText('20')).toBeInTheDocument();
+    });
+
+    it('renders a line chart without crashing when title is omitted', () => {
+      const noTitle = JSON.stringify({
+        type: 'line',
+        labels: ['Mon', 'Tue'],
+        datasets: [{ label: 'pace', data: [530, 520] }],
+      });
+      const { container } = render(<ChartBlock content={noTitle} />);
+      expect(container.querySelector('table')).toBeInTheDocument();
+    });
+  });
+
+  describe('multiple datasets', () => {
+    it('shows a legend when a bar chart has more than one dataset', () => {
+      const multi = JSON.stringify({
+        type: 'bar',
+        title: 'Comparison',
+        labels: ['Week 1', 'Week 2'],
+        datasets: [
+          { label: 'Running', data: [20, 25] },
+          { label: 'Cycling', data: [50, 60] },
+        ],
+      });
+      render(<ChartBlock content={multi} />);
+      expect(screen.getByText('Running')).toBeInTheDocument();
+      expect(screen.getByText('Cycling')).toBeInTheDocument();
+    });
+
+    it('does not show a legend flex-wrap container for a single-dataset bar chart', () => {
+      const { container } = render(<ChartBlock content={validBarChart} />);
+      // Legend only renders when datasets.length > 1
+      const legendContainer = container.querySelector('.flex.flex-wrap.gap-3');
+      expect(legendContainer).not.toBeInTheDocument();
+    });
+
+    it('renders all dataset columns in a multi-dataset line chart table', () => {
+      const multi = JSON.stringify({
+        type: 'line',
+        title: 'Heart Rate Zones',
+        labels: ['Run 1', 'Run 2'],
+        datasets: [
+          { label: 'Avg HR', data: [148, 155] },
+          { label: 'Max HR', data: [172, 180] },
+        ],
+      });
+      render(<ChartBlock content={multi} />);
+      expect(screen.getByText('Avg HR')).toBeInTheDocument();
+      expect(screen.getByText('Max HR')).toBeInTheDocument();
+      expect(screen.getByText('148')).toBeInTheDocument();
+      expect(screen.getByText('180')).toBeInTheDocument();
+    });
+  });
+
+  describe('bar chart with all-zero values', () => {
+    it('renders without crashing when all data values are zero', () => {
+      const allZero = JSON.stringify({
+        type: 'bar',
+        title: 'Empty Week',
+        labels: ['Mon', 'Tue', 'Wed'],
+        datasets: [{ label: 'miles', data: [0, 0, 0] }],
+      });
+      expect(() => render(<ChartBlock content={allZero} />)).not.toThrow();
+      expect(screen.getByText('Empty Week')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/GarminStatus.test.tsx
+++ b/src/components/GarminStatus.test.tsx
@@ -52,4 +52,35 @@ describe('GarminStatus', () => {
     await user.click(screen.getByRole('button', { name: /sign out/i }));
     expect(onLogout).toHaveBeenCalledOnce();
   });
+
+  it('shows "Connected" without an email parenthetical when no email is provided', () => {
+    render(<GarminStatus connected={true} onLoginClick={noop} onLogout={noop} />);
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    // No parenthetical email element
+    expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
+  });
+
+  it('sets a descriptive title attribute when connected with an email', () => {
+    const { container } = render(
+      <GarminStatus
+        connected={true}
+        email="athlete@test.com"
+        onLoginClick={noop}
+        onLogout={noop}
+      />
+    );
+    expect(container.querySelector('[title="Connected as athlete@test.com"]')).toBeInTheDocument();
+  });
+
+  it('does not show a Sign out button when disconnected', () => {
+    render(<GarminStatus connected={false} onLoginClick={noop} onLogout={noop} />);
+    expect(screen.queryByRole('button', { name: /sign out/i })).not.toBeInTheDocument();
+  });
+
+  it('does not show a Connect button when connected', () => {
+    render(
+      <GarminStatus connected={true} email="x@y.com" onLoginClick={noop} onLogout={noop} />
+    );
+    expect(screen.queryByRole('button', { name: /connect/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/components/LoginModal.test.tsx
+++ b/src/components/LoginModal.test.tsx
@@ -98,4 +98,110 @@ describe('LoginModal', () => {
     await user.click(screen.getByRole('button', { name: /back/i }));
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
   });
+
+  it('shows loading state while the sign-in request is in flight', async () => {
+    let unblock!: () => void;
+    server.use(
+      http.post('/api/auth/login', () =>
+        new Promise<Response>((resolve) => {
+          unblock = () => resolve(HttpResponse.json({ status: 'ok' }));
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<LoginModal onSuccess={vi.fn()} />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Signing in…')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
+
+    // Resolve to avoid pending promise warnings
+    unblock();
+    await waitFor(() => expect(screen.queryByText('Signing in…')).not.toBeInTheDocument());
+  });
+
+  it('shows a network error message when the login fetch fails', async () => {
+    server.use(http.post('/api/auth/login', () => HttpResponse.error()));
+
+    const user = userEvent.setup();
+    render(<LoginModal onSuccess={vi.fn()} />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(screen.getByText(/network error/i)).toBeInTheDocument());
+  });
+
+  it('shows an error message on MFA verification failure', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ status: 'mfa_required', session_id: 'sess-123' })
+      ),
+      http.post('/api/auth/mfa', () =>
+        HttpResponse.json({ detail: 'Invalid code' }, { status: 401 })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<LoginModal onSuccess={vi.fn()} />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument());
+    await user.type(screen.getByLabelText(/verification code/i), '000000');
+
+    await waitFor(() => expect(screen.getByText('Invalid code')).toBeInTheDocument());
+  });
+
+  it('clears the error message when navigating back from the MFA step', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ status: 'mfa_required', session_id: 'sess-123' })
+      ),
+      http.post('/api/auth/mfa', () =>
+        HttpResponse.json({ detail: 'Bad code' }, { status: 401 })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<LoginModal onSuccess={vi.fn()} />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument());
+    await user.type(screen.getByLabelText(/verification code/i), '000000');
+    await waitFor(() => expect(screen.getByText('Bad code')).toBeInTheDocument());
+
+    // Navigate back — error should be cleared
+    await user.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.queryByText('Bad code')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+
+  it('shows a network error message when the MFA fetch fails', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ status: 'mfa_required', session_id: 'sess-123' })
+      ),
+      http.post('/api/auth/mfa', () => HttpResponse.error())
+    );
+
+    const user = userEvent.setup();
+    render(<LoginModal onSuccess={vi.fn()} />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument());
+    await user.type(screen.getByLabelText(/verification code/i), '123456');
+
+    await waitFor(() => expect(screen.getByText(/network error/i)).toBeInTheDocument());
+  });
 });

--- a/src/components/MessageBubble.test.tsx
+++ b/src/components/MessageBubble.test.tsx
@@ -124,4 +124,95 @@ describe('MessageBubble', () => {
     expect(container.querySelector('pre')).toBeInTheDocument();
     expect(screen.getByText('print("hello")')).toBeInTheDocument();
   });
+
+  it('shows "…" placeholder for empty assistant content when not streaming', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: '' }} isStreaming={false} />
+    );
+    // AssistantContent returns a <span>…</span> when blocks array is empty
+    expect(container.querySelector('span')).toBeInTheDocument();
+    expect(container.textContent).toContain('…');
+  });
+
+  it('renders a blockquote for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: '> Quoted text here' }} />
+    );
+    expect(container.querySelector('blockquote')).toBeInTheDocument();
+    expect(screen.getByText('Quoted text here')).toBeInTheDocument();
+  });
+
+  it('renders a horizontal rule for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: '---' }} />
+    );
+    expect(container.querySelector('hr')).toBeInTheDocument();
+  });
+
+  it('renders an ordered list for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble
+        message={{ role: 'assistant', content: '1. Step one\n2. Step two\n3. Step three' }}
+      />
+    );
+    expect(container.querySelector('ol')).toBeInTheDocument();
+    expect(container.querySelectorAll('li')).toHaveLength(3);
+    expect(screen.getByText('Step one')).toBeInTheDocument();
+  });
+
+  it('renders an H1 heading for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: '# Top Level Heading' }} />
+    );
+    const h1 = container.querySelector('h1');
+    expect(h1).toBeInTheDocument();
+    expect(h1).toHaveTextContent('Top Level Heading');
+  });
+
+  it('renders an H3 heading for assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: '### Sub Heading' }} />
+    );
+    const h3 = container.querySelector('h3');
+    expect(h3).toBeInTheDocument();
+    expect(h3).toHaveTextContent('Sub Heading');
+  });
+
+  it('renders inline code in assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: 'Run `npm install` first' }} />
+    );
+    expect(container.querySelector('code')).toBeInTheDocument();
+    expect(screen.getByText('npm install')).toBeInTheDocument();
+  });
+
+  it('renders italic text in assistant messages', () => {
+    const { container } = render(
+      <MessageBubble message={{ role: 'assistant', content: 'This is *emphasized* text' }} />
+    );
+    expect(container.querySelector('em')).toHaveTextContent('emphasized');
+  });
+
+  it('renders links in assistant messages', () => {
+    const { container } = render(
+      <MessageBubble
+        message={{
+          role: 'assistant',
+          content: 'See [Garmin Connect](https://connect.garmin.com)',
+        }}
+      />
+    );
+    const link = container.querySelector('a');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('Garmin Connect');
+    expect(link).toHaveAttribute('href', 'https://connect.garmin.com');
+  });
+
+  it('preserves whitespace in user messages with newlines', () => {
+    render(
+      <MessageBubble message={{ role: 'user', content: 'Line one\nLine two' }} />
+    );
+    // User messages use whitespace-pre-wrap so newlines are preserved in the DOM
+    expect(screen.getByText('Line one\nLine two')).toBeInTheDocument();
+  });
 });

--- a/src/lib/markdown.test.tsx
+++ b/src/lib/markdown.test.tsx
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { parseMarkdownBlocks, renderInline } from '@/lib/markdown';
+
+// Helper to render renderInline output inside a real DOM node
+function Inline({ text }: { text: string }) {
+  return <span>{renderInline(text)}</span>;
+}
+
+// ── renderInline ──────────────────────────────────────────────────────────────
+
+describe('renderInline', () => {
+  it('renders plain text unchanged', () => {
+    render(<Inline text="Hello world" />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('renders **bold** as <strong>', () => {
+    const { container } = render(<Inline text="**bold text**" />);
+    const strong = container.querySelector('strong');
+    expect(strong).toBeInTheDocument();
+    expect(strong).toHaveTextContent('bold text');
+  });
+
+  it('renders __bold__ as <strong>', () => {
+    const { container } = render(<Inline text="__underline bold__" />);
+    const strong = container.querySelector('strong');
+    expect(strong).toBeInTheDocument();
+    expect(strong).toHaveTextContent('underline bold');
+  });
+
+  it('renders *italic* as <em>', () => {
+    const { container } = render(<Inline text="*italicized*" />);
+    const em = container.querySelector('em');
+    expect(em).toBeInTheDocument();
+    expect(em).toHaveTextContent('italicized');
+  });
+
+  it('renders _italic_ as <em>', () => {
+    const { container } = render(<Inline text="_underscore italic_" />);
+    const em = container.querySelector('em');
+    expect(em).toBeInTheDocument();
+    expect(em).toHaveTextContent('underscore italic');
+  });
+
+  it('renders `code` as <code>', () => {
+    const { container } = render(<Inline text="`inline code`" />);
+    const code = container.querySelector('code');
+    expect(code).toBeInTheDocument();
+    expect(code).toHaveTextContent('inline code');
+  });
+
+  it('renders [text](url) as an <a> with correct href, target and rel', () => {
+    const { container } = render(<Inline text="[click here](https://example.com)" />);
+    const link = container.querySelector('a');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('click here');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('renders mixed bold and italic in the same string', () => {
+    const { container } = render(<Inline text="**Training Readiness**: *72*" />);
+    expect(container.querySelector('strong')).toHaveTextContent('Training Readiness');
+    expect(container.querySelector('em')).toHaveTextContent('72');
+  });
+
+  it('renders plain text when there are no inline markers', () => {
+    render(<Inline text="No formatting here at all" />);
+    expect(screen.getByText('No formatting here at all')).toBeInTheDocument();
+  });
+});
+
+// ── parseMarkdownBlocks ───────────────────────────────────────────────────────
+
+describe('parseMarkdownBlocks', () => {
+  it('returns an empty array for an empty string', () => {
+    expect(parseMarkdownBlocks('')).toEqual([]);
+  });
+
+  it('returns an empty array for whitespace-only content', () => {
+    expect(parseMarkdownBlocks('   \n\n   ')).toEqual([]);
+  });
+
+  it('parses an H1 heading', () => {
+    const blocks = parseMarkdownBlocks('# Title');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ kind: 'heading', level: 1, text: 'Title' });
+  });
+
+  it('parses an H2 heading', () => {
+    const blocks = parseMarkdownBlocks('## Section');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ kind: 'heading', level: 2, text: 'Section' });
+  });
+
+  it('parses an H3 heading', () => {
+    const blocks = parseMarkdownBlocks('### Sub');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ kind: 'heading', level: 3, text: 'Sub' });
+  });
+
+  it('parses a single-line paragraph', () => {
+    const blocks = parseMarkdownBlocks('Hello world');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'paragraph', lines: ['Hello world'] });
+  });
+
+  it('combines consecutive text lines into one paragraph block', () => {
+    const blocks = parseMarkdownBlocks('Line one\nLine two\nLine three');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      lines: ['Line one', 'Line two', 'Line three'],
+    });
+  });
+
+  it('splits content into separate paragraph blocks at blank lines', () => {
+    const blocks = parseMarkdownBlocks('Para one\n\nPara two');
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ kind: 'paragraph', lines: ['Para one'] });
+    expect(blocks[1]).toMatchObject({ kind: 'paragraph', lines: ['Para two'] });
+  });
+
+  it('parses a horizontal rule with ---', () => {
+    expect(parseMarkdownBlocks('---')).toEqual([{ kind: 'hr' }]);
+  });
+
+  it('parses a horizontal rule with ***', () => {
+    expect(parseMarkdownBlocks('***')).toEqual([{ kind: 'hr' }]);
+  });
+
+  it('parses a fenced code block with a language tag', () => {
+    const blocks = parseMarkdownBlocks('```python\nprint("hello")\n```');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'code',
+      language: 'python',
+      content: 'print("hello")',
+    });
+  });
+
+  it('parses a fenced code block without a language tag', () => {
+    const blocks = parseMarkdownBlocks('```\nsome code\n```');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'code', language: '', content: 'some code' });
+  });
+
+  it('parses a multi-line fenced code block', () => {
+    const blocks = parseMarkdownBlocks('```js\nline1\nline2\nline3\n```');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'code', content: 'line1\nline2\nline3' });
+  });
+
+  it('parses a blockquote', () => {
+    const blocks = parseMarkdownBlocks('> First line\n> Second line');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'blockquote',
+      lines: ['First line', 'Second line'],
+    });
+  });
+
+  it('parses a GFM table', () => {
+    const md = '| Name | Score |\n|------|-------|\n| Alice | 95 |\n| Bob | 87 |';
+    const blocks = parseMarkdownBlocks(md);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'table',
+      headers: ['Name', 'Score'],
+      rows: [
+        ['Alice', '95'],
+        ['Bob', '87'],
+      ],
+    });
+  });
+
+  it('parses an unordered list with - markers', () => {
+    const blocks = parseMarkdownBlocks('- Item A\n- Item B');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'list',
+      ordered: false,
+      items: ['Item A', 'Item B'],
+    });
+  });
+
+  it('parses an unordered list with * markers', () => {
+    const blocks = parseMarkdownBlocks('* Alpha\n* Beta');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'list', ordered: false, items: ['Alpha', 'Beta'] });
+  });
+
+  it('parses an ordered list', () => {
+    const blocks = parseMarkdownBlocks('1. First\n2. Second\n3. Third');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'list',
+      ordered: true,
+      items: ['First', 'Second', 'Third'],
+    });
+  });
+
+  it('parses mixed content: heading + paragraph + unordered list', () => {
+    const md = '## Summary\n\nSome text.\n\n- One\n- Two';
+    const blocks = parseMarkdownBlocks(md);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toMatchObject({ kind: 'heading', level: 2, text: 'Summary' });
+    expect(blocks[1]).toMatchObject({ kind: 'paragraph', lines: ['Some text.'] });
+    expect(blocks[2]).toMatchObject({ kind: 'list', ordered: false });
+  });
+
+  it('parses a heading immediately followed by a list (no blank line between)', () => {
+    const blocks = parseMarkdownBlocks('### Items\n- A\n- B');
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ kind: 'heading' });
+    expect(blocks[1]).toMatchObject({ kind: 'list' });
+  });
+
+  it('parses a code block followed by a paragraph', () => {
+    const md = '```\ncode here\n```\n\nAfter the code.';
+    const blocks = parseMarkdownBlocks(md);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ kind: 'code', content: 'code here' });
+    expect(blocks[1]).toMatchObject({ kind: 'paragraph', lines: ['After the code.'] });
+  });
+
+  it('parses a chart code block (language = chart)', () => {
+    const chartJson = '{"type":"bar","labels":["A"],"datasets":[{"label":"x","data":[1]}]}';
+    const blocks = parseMarkdownBlocks(`\`\`\`chart\n${chartJson}\n\`\`\``);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'code', language: 'chart', content: chartJson });
+  });
+});


### PR DESCRIPTION
Adds 61 new tests across all components and the markdown utility library.

- New file: `src/lib/markdown.test.tsx` — 31 tests for `parseMarkdownBlocks` + `renderInline`
- Extended MessageBubble, ChatInterface, ChartBlock, LoginModal, GarminStatus test files

Related to #27

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the test suite with 61 tests to improve coverage and catch regressions across UI and markdown parsing. Related to #27: charts (no title, legends, zero values), chat login/pending questions and session token, login modal loading/MFA errors, GarminStatus states, MessageBubble markdown rendering, and markdown block/inline parsing.

<sup>Written for commit e15fa7cb86827b5190745a0a1a65c57f4df2698b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

