### PR TITLE
fix(e2e): use exact match for Back button to avoid strict mode violation

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -159,7 +159,7 @@ test('2FA: Back button returns to credentials step', async ({ page }) => {
   await page.getByRole('button', { name: /sign in/i }).click();
 
   await expect(page.getByLabel('Verification code')).toBeVisible();
-  await page.getByRole('button', { name: /back/i }).click();
+  await page.getByRole('button', { name: 'Back', exact: true }).click();
 
   await expect(page.getByLabel('Email')).toBeVisible();
 });


### PR DESCRIPTION
SuggestedQuestions renders buttons containing 'back' as a substring (e.g. 'how do I pick back up without getting injured?'). These elements remain in the DOM behind the login modal overlay, causing Playwright strict mode to find 2 elements when matching /back/i. Using exact:true restricts the match to the button whose accessible name is exactly 'Back'.

Closes #34

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix strict-mode failures in the 2FA e2e test by targeting the Back button with an exact accessible name instead of /back/i. This avoids collisions with hidden suggested-question buttons containing “back” and makes the test reliable (closes #34).

<sup>Written for commit 0958f44b0abe607e63220ba00e0dab6837f84b5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

