### PR TITLE
fix: surface Claude errors, fix memory 503, URL-encode display_name

### DIFF
--- a/backend/garmin_client.py
+++ b/backend/garmin_client.py
@@ -8,6 +8,7 @@ isolated — no shared global state.
 import logging
 from datetime import date, timedelta
 from typing import Any
+from urllib.parse import quote
 
 import garth
 
@@ -45,7 +46,7 @@ def get_recent_activities(client: garth.Client, limit: int = 200, page_size: int
 
 def get_daily_summary(client: garth.Client, display_name: str, date_str: str) -> dict[str, Any]:
     return client.connectapi(
-        f"/usersummary-service/usersummary/daily/{display_name}",
+        f"/usersummary-service/usersummary/daily/{quote(display_name, safe='')}",
         params={"calendarDate": date_str},
     )
 
@@ -58,7 +59,7 @@ def get_training_status(client: garth.Client, date_str: str) -> dict[str, Any]:
 
 def get_sleep_data(client: garth.Client, display_name: str, date_str: str) -> dict[str, Any]:
     return client.connectapi(
-        f"/wellness-service/wellness/dailySleepData/{display_name}",
+        f"/wellness-service/wellness/dailySleepData/{quote(display_name, safe='')}",
         params={"date": date_str},
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -549,14 +549,21 @@ async def ask(body: AskRequest) -> StreamingResponse:
         )
 
     def stream_tokens():
-        with claude.messages.stream(
-            model="claude-sonnet-4-6",
-            max_tokens=512,
-            system=system_prompt,
-            messages=messages,
-        ) as stream:
-            for text in stream.text_stream:
-                yield text
+        try:
+            with claude.messages.stream(
+                model="claude-sonnet-4-6",
+                max_tokens=512,
+                system=system_prompt,
+                messages=messages,
+            ) as stream:
+                for text in stream.text_stream:
+                    yield text
+        except Exception as exc:
+            logger.error("Claude stream failed: %s", exc, exc_info=True)
+            if _detection_executor:
+                _detection_executor.shutdown(wait=False)
+            yield f"Sorry, I encountered an error while generating a response: {exc}"
+            return
 
         # After the main stream completes, check for a detected memory
         if _detection_future is not None:

--- a/backend/memory_service.py
+++ b/backend/memory_service.py
@@ -7,6 +7,7 @@ Provides:
  - Autonomous memory detection via Claude Haiku
 """
 
+import base64
 import hashlib
 import json
 import logging
@@ -53,16 +54,45 @@ Respond with a JSON object only (no markdown):
 If should_store is false, set key, content, and category to empty strings."""
 
 
+def _jwt_sub(access_token: str) -> str:
+    """Decode a JWT payload (no signature verification) and return the sub claim."""
+    parts = access_token.split(".")
+    if len(parts) < 2:
+        raise ValueError("Not a valid JWT")
+    payload = parts[1]
+    padding = 4 - len(payload) % 4
+    if padding != 4:
+        payload += "=" * padding
+    data = json.loads(base64.b64decode(payload))
+    sub = str(data.get("sub", ""))
+    if not sub:
+        raise ValueError("JWT has no sub claim")
+    return sub
+
+
 def get_user_id_hash(client: garth.Client) -> str:
-    """Return SHA-256 of the Garmin user's numeric user ID."""
+    """Return SHA-256 of the Garmin user's numeric user ID.
+
+    Tries the Garmin profile API first. If that fails (e.g. 403 or network
+    error), falls back to decoding the sub claim from the OAuth2 access token
+    so that memory operations remain available when the Garmin API is flaky.
+    """
+    # Primary: Garmin profile API
     try:
         profile = client.connectapi("/userprofile-service/userprofile/personal-information")
         user_id = str((profile or {}).get("userId", ""))
-        if not user_id:
-            raise ValueError("No userId in Garmin profile")
-        return hashlib.sha256(user_id.encode()).hexdigest()
+        if user_id:
+            return hashlib.sha256(user_id.encode()).hexdigest()
+        logger.warning("Garmin profile returned no userId; falling back to JWT sub")
     except Exception as exc:
-        raise ValueError(f"Could not derive user identity: {exc}") from exc
+        logger.warning("Profile API failed, falling back to JWT sub: %s", exc)
+
+    # Fallback: JWT sub claim from OAuth2 access token (no network call)
+    try:
+        sub = _jwt_sub(client.oauth2_token.access_token)
+        return hashlib.sha256(sub.encode()).hexdigest()
+    except Exception as exc:
+        raise ValueError(f"Could not derive user identity from profile API or OAuth token: {exc}") from exc
 
 
 # ── CRUD ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes three issues causing the agent to stop responding:

1. **Chat returning "..."** — `stream_tokens()` now wraps the Claude API call in try/except so any exception yields a visible error message instead of an empty stream.
2. **Memory 503** — `get_user_id_hash()` falls back to the OAuth2 JWT `sub` claim when Garmin's profile API fails, so memory operations survive Garmin API flakiness.
3. **403 on data endpoints** — email-like `displayName` values (containing `@`) are now URL-encoded before insertion into URL paths.

Closes #37

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three issues that caused the agent to stop responding. Errors are now surfaced in chat, memory stays available during Garmin outages, and display names with special characters no longer trigger 403s.

- **Bug Fixes**
  - Show Claude stream errors: wrap `claude.messages.stream(...)` in try/except, log, and emit a clear message instead of "..." (also shuts down detection executor on failure).
  - Prevent memory 503s: `get_user_id_hash()` falls back to the OAuth2 JWT `sub` claim when the Garmin profile API fails, then hashes it.
  - Stop 403s on data endpoints: URL-encode `display_name` with `quote(..., safe='')` for usersummary and wellness requests to handle `@` and other special chars.

<sup>Written for commit 84a6ca3854e996061d03addd824f7e9b40530449. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

