### PR TITLE
fix: resolve 503 on memory pane and teach Claude about memory system

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -649,6 +649,12 @@ Use Markdown formatting: **bold** key stats, use tables for comparing multiple r
 ```chart blocks for 3+ data points. Do NOT use H1 headings.
 Today's date: {today}.
 
+## Memory System
+This system automatically detects and stores information the athlete shares about themselves \
+(race events, goals, injuries, training context). When relevant memories are available, \
+they appear below. Do NOT tell the athlete you cannot remember things — the memory system \
+handles persistence automatically across sessions.
+
 ## User's Garmin Data
 {_json.dumps(garmin_data, indent=2)}"""
 
@@ -811,6 +817,17 @@ First check ATL:CTL history. Most injuries are load management errors, not biome
 - One question max if you need clarification — not a list of clarifying questions
 - If a full answer requires more than 200 words, give the most actionable 150 words and note what was omitted
 </communication_style>
+
+---
+
+<memory_system>
+This system automatically detects and stores information the athlete shares about themselves
+across sessions (race events, goals, injuries, training context, personal notes). Stored
+memories are injected into this prompt under "Athlete's Persistent Memory" when available.
+Do NOT tell the athlete you cannot remember things between sessions — the memory system
+handles this automatically. When the athlete shares new personal information, acknowledge
+it naturally; the system will store it in the background.
+</memory_system>
 
 ---
 

--- a/backend/memory_service.py
+++ b/backend/memory_service.py
@@ -73,9 +73,11 @@ def _jwt_sub(access_token: str) -> str:
 def get_user_id_hash(client: garth.Client) -> str:
     """Return SHA-256 of the Garmin user's numeric user ID.
 
-    Tries the Garmin profile API first. If that fails (e.g. 403 or network
-    error), falls back to decoding the sub claim from the OAuth2 access token
-    so that memory operations remain available when the Garmin API is flaky.
+    Tries multiple sources in order so memory operations stay available even
+    when the Garmin API is flaky or tokens are opaque (non-JWT):
+      1. Garmin profile API (network call, returns stable numeric userId)
+      2. JWT sub claim from OAuth2 access token (no network, only works for JWT tokens)
+      3. OAuth1 oauth_token (stable per Garmin account, always available, no network)
     """
     # Primary: Garmin profile API
     try:
@@ -83,16 +85,31 @@ def get_user_id_hash(client: garth.Client) -> str:
         user_id = str((profile or {}).get("userId", ""))
         if user_id:
             return hashlib.sha256(user_id.encode()).hexdigest()
-        logger.warning("Garmin profile returned no userId; falling back to JWT sub")
+        logger.warning("Garmin profile returned no userId; trying JWT sub")
     except Exception as exc:
-        logger.warning("Profile API failed, falling back to JWT sub: %s", exc)
+        logger.warning("Profile API failed, trying JWT sub: %s", exc)
 
-    # Fallback: JWT sub claim from OAuth2 access token (no network call)
+    # Second fallback: JWT sub claim from OAuth2 access token (no network call)
     try:
         sub = _jwt_sub(client.oauth2_token.access_token)
         return hashlib.sha256(sub.encode()).hexdigest()
     except Exception as exc:
-        raise ValueError(f"Could not derive user identity from profile API or OAuth token: {exc}") from exc
+        logger.warning("JWT sub fallback failed, trying OAuth1 token: %s", exc)
+
+    # Third fallback: OAuth1 oauth_token — stable per Garmin account, always present
+    try:
+        oauth1 = getattr(client, "oauth1_token", None)
+        if oauth1:
+            token = getattr(oauth1, "oauth_token", "") or ""
+            if token:
+                return hashlib.sha256(token.encode()).hexdigest()
+        logger.warning("OAuth1 fallback: no oauth_token found on client")
+    except Exception as exc:
+        logger.warning("OAuth1 token fallback failed: %s", exc)
+
+    raise ValueError(
+        "Could not derive user identity from profile API, JWT, or OAuth1 token"
+    )
 
 
 # ── CRUD ──────────────────────────────────────────────────────────────────────

--- a/backend/test_memory_service.py
+++ b/backend/test_memory_service.py
@@ -1,0 +1,145 @@
+"""Unit tests for memory_service.get_user_id_hash.
+
+Run with:
+    cd backend && pytest test_memory_service.py -v
+"""
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import garth
+import pytest
+from garth.auth_tokens import OAuth1Token, OAuth2Token
+
+from memory_service import get_user_id_hash
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_client(
+    *,
+    oauth1_token: str = "stable_oauth1_token",
+    access_token: str = "opaque_access_token",  # not a JWT
+) -> garth.Client:
+    """Return a garth Client pre-loaded with fake tokens."""
+    oauth1 = OAuth1Token(
+        oauth_token=oauth1_token,
+        oauth_token_secret="secret",
+        mfa_token=None,
+        mfa_expiration_timestamp=None,
+        domain="garmin.com",
+    )
+    oauth2 = OAuth2Token(
+        scope="CONNECT_READ",
+        jti="jti-123",
+        token_type="Bearer",
+        access_token=access_token,
+        refresh_token="refresh_token",
+        expires_in=3600,
+        expires_at=9_999_999_999,
+        refresh_token_expires_in=7_776_000,
+        refresh_token_expires_at=9_999_999_999,
+    )
+    client = garth.Client()
+    client.configure(oauth1_token=oauth1, oauth2_token=oauth2, domain="garmin.com")
+    return client
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+
+class TestGetUserIdHashPrimaryPath:
+    def test_returns_hash_of_user_id_from_profile(self):
+        client = _make_client()
+        client.connectapi = MagicMock(return_value={"userId": 12345678})
+
+        result = get_user_id_hash(client)
+
+        assert result == _sha256("12345678")
+
+    def test_profile_with_string_user_id(self):
+        client = _make_client()
+        client.connectapi = MagicMock(return_value={"userId": "99999999"})
+
+        result = get_user_id_hash(client)
+
+        assert result == _sha256("99999999")
+
+
+class TestGetUserIdHashJwtFallback:
+    def _make_jwt_access_token(self, sub: str) -> str:
+        """Create a minimal fake JWT with a sub claim (not cryptographically valid)."""
+        import base64
+        import json
+
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": sub}).encode()).decode()
+        return f"header.{payload}.sig"
+
+    def test_falls_back_to_jwt_sub_when_profile_fails(self):
+        jwt_token = self._make_jwt_access_token("user-sub-abc123")
+        client = _make_client(access_token=jwt_token)
+        client.connectapi = MagicMock(side_effect=Exception("API error"))
+
+        result = get_user_id_hash(client)
+
+        assert result == _sha256("user-sub-abc123")
+
+    def test_falls_back_to_jwt_sub_when_profile_returns_no_user_id(self):
+        jwt_token = self._make_jwt_access_token("user-sub-xyz")
+        client = _make_client(access_token=jwt_token)
+        client.connectapi = MagicMock(return_value={"emailAddress": "runner@example.com"})
+
+        result = get_user_id_hash(client)
+
+        assert result == _sha256("user-sub-xyz")
+
+
+class TestGetUserIdHashOAuth1Fallback:
+    def test_falls_back_to_oauth1_token_when_profile_and_jwt_fail(self):
+        """This is the critical fix: opaque (non-JWT) access tokens must use OAuth1."""
+        client = _make_client(
+            oauth1_token="stable_oauth1_token_abc",
+            access_token="opaque_no_dots_token",  # not a JWT — no dots
+        )
+        client.connectapi = MagicMock(side_effect=Exception("Garmin API down"))
+
+        result = get_user_id_hash(client)
+
+        assert result == _sha256("stable_oauth1_token_abc")
+
+    def test_oauth1_hash_is_stable(self):
+        """Same OAuth1 token must always produce the same hash."""
+        client = _make_client(oauth1_token="my_garmin_oauth1")
+        client.connectapi = MagicMock(side_effect=Exception("API error"))
+
+        result1 = get_user_id_hash(client)
+        result2 = get_user_id_hash(client)
+
+        assert result1 == result2
+
+    def test_different_oauth1_tokens_produce_different_hashes(self):
+        client_a = _make_client(oauth1_token="token_user_a")
+        client_b = _make_client(oauth1_token="token_user_b")
+        client_a.connectapi = MagicMock(side_effect=Exception("error"))
+        client_b.connectapi = MagicMock(side_effect=Exception("error"))
+
+        result_a = get_user_id_hash(client_a)
+        result_b = get_user_id_hash(client_b)
+
+        assert result_a != result_b
+
+
+class TestGetUserIdHashErrors:
+    def test_raises_when_all_sources_fail(self):
+        client = _make_client(oauth1_token="", access_token="no_dots")
+        client.connectapi = MagicMock(side_effect=Exception("API error"))
+        # Force oauth1_token.oauth_token to be empty
+        client.oauth1_token.oauth_token = ""
+
+        with pytest.raises(ValueError, match="Could not derive user identity"):
+            get_user_id_hash(client)


### PR DESCRIPTION
Closes #40

## What

- Fix 503 on memory pane by adding OAuth1 token fallback in `get_user_id_hash`
- Tell Claude about the automatic memory system so it stops claiming it can't remember things
- Add `test_memory_service.py` covering all three resolution paths

## Root Cause

Garmin's OAuth2 access token is opaque (no dots), not a standard JWT. The existing `_jwt_sub` fallback always raised `ValueError`, which propagated as HTTP 503. The fix adds OAuth1 `oauth_token` as a third fallback — always available, stable per account, no network call.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 503 errors on the memory pane by adding an OAuth1 token fallback to derive a stable user ID hash. Also updates system prompts to explain the automatic memory system so the assistant doesn’t claim it can’t remember.

- **Bug Fixes**
  - `get_user_id_hash` now falls back in order: profile API → JWT sub → OAuth1 `oauth_token`; this handles opaque OAuth2 tokens and prevents 503s without extra network calls.
  - Added unit tests covering all three paths and the all-fail error case.

- **New Features**
  - Injected a “Memory System” section into both system prompts, noting that memories persist across sessions and the assistant should not claim it can’t remember.

<sup>Written for commit c550dbbeabce962536beae5e382e2ed652f2cd7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

