### PR TITLE
fix(e2e): await setupMfaMocks to ensure routes register before navigation

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -125,7 +125,7 @@ test('wrong credentials shows error message', async ({ page }) => {
 // ── MFA flow ──────────────────────────────────────────────────────────────────
 
 test('2FA flow: advances to MFA step then logs in', async ({ page }) => {
-  setupMfaMocks(page);
+  await setupMfaMocks(page);
   await mockChat(page);
   await page.goto('/');
 
@@ -148,7 +148,7 @@ test('2FA flow: advances to MFA step then logs in', async ({ page }) => {
 });
 
 test('2FA: Back button returns to credentials step', async ({ page }) => {
-  setupMfaMocks(page);
+  await setupMfaMocks(page);
   await page.goto('/');
 
   await page.getByPlaceholder(/ask about your activities/i).fill('test');

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -58,11 +58,11 @@ export function setupLoginMocks(page: Page) {
 }
 
 /** MFA login flow mock (two-step). */
-export function setupMfaMocks(page: Page) {
+export async function setupMfaMocks(page: Page) {
   let mfaStep = false;
   let loggedIn = false;
 
-  page.route('/api/auth/login', (route) => {
+  await page.route('/api/auth/login', (route) => {
     mfaStep = true;
     route.fulfill({
       status: 200,
@@ -70,7 +70,7 @@ export function setupMfaMocks(page: Page) {
     });
   });
 
-  page.route('/api/auth/mfa', (route) => {
+  await page.route('/api/auth/mfa', (route) => {
     loggedIn = true;
     mfaStep = false;
     route.fulfill({
@@ -79,7 +79,7 @@ export function setupMfaMocks(page: Page) {
     });
   });
 
-  page.route('/api/auth/status*', (route) => {
+  await page.route('/api/auth/status*', (route) => {
     if (loggedIn) {
       route.fulfill({ status: 200, json: { connected: true, email: FAKE_EMAIL } });
     } else {


### PR DESCRIPTION
Fixes the nightly E2E race condition where `setupMfaMocks()` called `page.route()` without awaiting, allowing requests to slip through to the real Next.js proxy before interception was active in CI.

Closes #42

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CI-only E2E race by awaiting MFA route mocks so interception is active before navigation, stabilizing the 2FA tests. Closes #42.

- **Bug Fixes**
  - Made `setupMfaMocks(page)` async and awaited each `page.route()` to register routes before `page.goto('/')`.
  - Updated both 2FA tests to `await setupMfaMocks(page)` to prevent requests from hitting the real Next.js proxy.

<sup>Written for commit 2d9071e1e1ff17c4a100e80919304de36c001091. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

