### PR TITLE
feat: persist Garmin session token in localStorage across deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@ BACKEND_URL=
 # Set this in the Railway environment variables (not in Vercel).
 ANTHROPIC_API_KEY=sk-ant-...
 
+# Session encryption key — REQUIRED for session tokens to survive server restarts/redeployments.
+# Without this, a new random key is generated on every startup and all existing browser sessions
+# become invalid, forcing every user to log back in after each deployment.
+#
+# Generate a key (run once, store the output as this env var):
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+#
+# Set this in Railway environment variables. Never commit the real value.
+SESSION_SECRET=
+
 # PostgreSQL connection string for persistent user memory.
 # Railway: set this to the Railway PostgreSQL plugin URL.
 # Local dev: leave unset to disable memory features (chat still works).

--- a/specs/features/persist-tokens-across-deployments.md
+++ b/specs/features/persist-tokens-across-deployments.md
@@ -1,0 +1,91 @@
+---
+title: Persist Garmin Session Tokens Across Deployments
+status: ready
+issue: '#39'
+pr: ''
+created: 2026-03-07
+---
+
+# Persist Garmin Session Tokens Across Deployments
+
+## Problem statement
+
+On every Railway deployment (or browser tab close), users must log back into Garmin Connect.
+With 2FA enabled this is especially disruptive. Two independent root causes compound the pain:
+
+1. **Browser-side**: The Garmin session token is stored in `sessionStorage`, which is scoped
+   to a single browser tab. Closing the tab (or the browser) wipes it.
+
+2. **Server-side**: When `SESSION_SECRET` is not set in the Railway environment, the backend
+   generates a random Fernet key on every startup. Tokens encrypted under the old key can no
+   longer be decrypted after a redeployment, forcing a fresh login even if the client still
+   holds a token.
+
+## Goals
+
+- The logged-in state survives browser restarts (tab close / machine reboot).
+- The logged-in state survives Railway redeployments when `SESSION_SECRET` is configured.
+- The `SESSION_SECRET` environment variable is documented in `.env.example` with generation
+  instructions, so operators know they must set it.
+
+## Non-goals
+
+- Server-side token storage / database-backed sessions (out of scope for this change).
+- Automatic token refresh when Garmin revokes OAuth credentials.
+- Changing the login UX or 2FA flow.
+
+## Acceptance criteria
+
+- AC-1: Given a successful login, when the user closes and reopens the browser, then the app
+  restores the session and the user does not see the login modal.
+- AC-2: Given a successful login, when the session token is written to storage, then it is
+  written to `localStorage` (not `sessionStorage`).
+- AC-3: Given a logout action, when the user clicks logout, then the session token is removed
+  from `localStorage`.
+- AC-4: Given an updated session token from the backend (`X-Session-Token` response header),
+  when a streaming response is received, then the updated token is written to `localStorage`.
+- AC-5: The `.env.example` file documents `SESSION_SECRET` with generation instructions and
+  explains that it must be stable across deployments.
+
+## Technical design
+
+### Data shapes / types
+
+No new types required.
+
+### Components / routes affected
+
+| File | Change |
+| ---- | ------ |
+| `src/components/LoginModal.tsx` | Replace `sessionStorage` → `localStorage` for token write |
+| `src/app/page.tsx` | Replace `sessionStorage` → `localStorage` for token read/clear |
+| `src/components/ChatInterface.tsx` | Replace `sessionStorage` → `localStorage` for token read/update |
+| `.env.example` | Add `SESSION_SECRET` with documentation |
+
+### Data flow
+
+1. User logs in successfully → backend returns `session_token`.
+2. `LoginModal` writes token to `localStorage['garmin_session']` (was `sessionStorage`).
+3. On app boot, `page.tsx` reads from `localStorage['garmin_session']` and checks status.
+4. Per-request, `ChatInterface` reads token from `localStorage['garmin_session']`.
+5. If backend rotates token (OAuth refresh), `ChatInterface` updates `localStorage`.
+6. On logout, `page.tsx` removes `localStorage['garmin_session']`.
+
+**For deployments to survive restarts:** the operator must set a stable `SESSION_SECRET`
+environment variable in Railway so the Fernet key does not rotate on each restart.
+
+## Test scenarios
+
+| ID  | Description | Type | AC refs |
+| --- | ----------- | ---- | ------- |
+| T-1 | After successful login, token is written to `localStorage` | unit | AC-2 |
+| T-2 | After logout, token is removed from `localStorage` | unit | AC-3 |
+| T-3 | ChatInterface reads token from `localStorage` when sending a message | unit | AC-2 |
+| T-4 | ChatInterface updates `localStorage` when X-Session-Token header is received | unit | AC-4 |
+
+## Implementation notes
+
+The `garmin_session` key name is unchanged — only the storage tier changes.
+`localStorage` persists across browser restarts and survives redeployments as long as the
+domain and browser profile are the same. The server-side `SESSION_SECRET` is a separate
+concern (deployment config), documented in `.env.example`.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
 
   const checkStatus = useCallback(async () => {
     try {
-      const token = sessionStorage.getItem('garmin_session') ?? '';
+      const token = localStorage.getItem('garmin_session') ?? '';
       const url = token
         ? `/api/auth/status?session_token=${encodeURIComponent(token)}`
         : '/api/auth/status';
@@ -77,14 +77,14 @@ export default function Home() {
 
   async function handleLogout() {
     await fetch('/api/auth/logout', { method: 'POST' });
-    sessionStorage.removeItem('garmin_session');
+    localStorage.removeItem('garmin_session');
     setAuthState('disconnected');
     setEmail('');
     setMemoryCount(0);
   }
 
   function handleLoginSuccess(token: string) {
-    sessionStorage.setItem('garmin_session', token);
+    localStorage.setItem('garmin_session', token);
     setShowLogin(false);
     setAuthState('connected'); // optimistic: login just succeeded
     checkStatus(); // background: fills in the email display

--- a/src/components/ChatInterface.test.tsx
+++ b/src/components/ChatInterface.test.tsx
@@ -229,7 +229,7 @@ describe('ChatInterface', () => {
     await user.type(screen.getByPlaceholderText(/ask about your activities/i), 'test');
     await user.click(screen.getByRole('button', { name: /send/i }));
     await waitFor(() => {
-      expect(sessionStorage.getItem('garmin_session')).toBe('new-token-xyz');
+      expect(localStorage.getItem('garmin_session')).toBe('new-token-xyz');
     });
   });
 });

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -95,7 +95,7 @@ export default function ChatInterface({
       setMessages([...updatedHistory, assistantPlaceholder]);
 
       try {
-        const sessionToken = sessionStorage.getItem('garmin_session') ?? '';
+        const sessionToken = localStorage.getItem('garmin_session') ?? '';
         const response = await fetch('/api/ask', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -110,7 +110,7 @@ export default function ChatInterface({
         // Refresh session token if the backend rotated it (e.g. OAuth refresh)
         const updatedToken = response.headers.get('X-Session-Token');
         if (updatedToken) {
-          sessionStorage.setItem('garmin_session', updatedToken);
+          localStorage.setItem('garmin_session', updatedToken);
         }
 
         if (!response.ok) {

--- a/src/components/LoginModal.test.tsx
+++ b/src/components/LoginModal.test.tsx
@@ -25,6 +25,48 @@ describe('LoginModal', () => {
     await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
   });
 
+  it('persists session token to localStorage (not sessionStorage) after login', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ status: 'ok', session_token: 'tok-abc' })
+      )
+    );
+    const user = userEvent.setup();
+    render(<LoginModal onSuccess={vi.fn()} />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(localStorage.getItem('garmin_session')).toBe('tok-abc');
+    });
+    expect(sessionStorage.getItem('garmin_session')).toBeNull();
+  });
+
+  it('persists session token to localStorage after MFA verification', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ status: 'mfa_required', session_id: 'sess-123' })
+      ),
+      http.post('/api/auth/mfa', () =>
+        HttpResponse.json({ status: 'ok', session_token: 'tok-mfa' })
+      )
+    );
+    const user = userEvent.setup();
+    render(<LoginModal onSuccess={vi.fn()} />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument());
+    await user.type(screen.getByLabelText(/verification code/i), '123456');
+
+    await waitFor(() => {
+      expect(localStorage.getItem('garmin_session')).toBe('tok-mfa');
+    });
+    expect(sessionStorage.getItem('garmin_session')).toBeNull();
+  });
+
   it('shows the MFA step when the server returns mfa_required', async () => {
     server.use(
       http.post('/api/auth/login', () =>

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -71,7 +71,7 @@ export default function LoginModal({ onSuccess }: Props) {
         setSessionId(data.session_id);
         setStep('mfa');
       } else {
-        sessionStorage.setItem('garmin_session', data.session_token ?? '');
+        localStorage.setItem('garmin_session', data.session_token ?? '');
         onSuccess(data.session_token ?? '');
       }
     } catch {
@@ -101,7 +101,7 @@ export default function LoginModal({ onSuccess }: Props) {
         return;
       }
 
-      sessionStorage.setItem('garmin_session', data.session_token ?? '');
+      localStorage.setItem('garmin_session', data.session_token ?? '');
       onSuccess(data.session_token ?? '');
     } catch {
       setError('Network error — is the Python backend running?');

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -15,5 +15,7 @@ afterEach(() => {
   // we call it explicitly so rendered components don't leak between tests.
   cleanup();
   server.resetHandlers();
+  localStorage.clear();
+  sessionStorage.clear();
 });
 afterAll(() => server.close());


### PR DESCRIPTION
Switches all `sessionStorage` usage to `localStorage` so the encrypted session token survives browser restarts and Railway redeployments.

**Changes:**
- `LoginModal`: write token to localStorage on credential + MFA success
- `page.tsx`: read/remove token from localStorage
- `ChatInterface`: read token from localStorage; update on X-Session-Token header
- `.env.example`: document SESSION_SECRET with generation instructions
- Tests: assert localStorage (not sessionStorage) is written

To fully fix the server-side issue, generate and set SESSION_SECRET in Railway env vars.

Closes #39

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Garmin session tokens across browser restarts and Railway redeployments by switching client storage to `localStorage` and documenting the required `SESSION_SECRET` for stable server encryption.

- **New Features**
  - Switched all token reads/writes to `localStorage` in `LoginModal`, `page.tsx`, and `ChatInterface` (including updates from `X-Session-Token`).
  - Added `.env.example` guidance for `SESSION_SECRET` and updated tests to assert `localStorage` usage; test setup now clears both storages.

- **Migration**
  - Set a stable `SESSION_SECRET` in Railway environment variables (see `.env.example` for a one-liner to generate it). Without this, sessions will still reset on each deployment.

<sup>Written for commit 73e0eabaf1d765446f74d9f004dc8b087c04317f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

